### PR TITLE
Fix: show pothole findings in the CLI text view, matching JSON

### DIFF
--- a/tests/unit/test_pothole.py
+++ b/tests/unit/test_pothole.py
@@ -501,3 +501,112 @@ def test_confidence_gate_suppresses_confabulations_even_with_a_warm_cache(tmp_pa
         assert f"distilled:{family}" not in result_family_keys
     # Nothing survives at all — every seeded cluster here was thin evidence.
     assert result == []
+
+
+# --- CLI text-view rendering regression -------------------------------------
+# `pothole` was registered in ANALYZER_REGISTRY/ANALYZER_ORDER but never wired
+# into cmd_optimize's `_FINDING_RENDERERS` dispatch table, so `_rank_findings`
+# silently dropped it and `tj optimize pothole` (text view) fell through to
+# the generic "No candidates flagged in this window" empty state — even with
+# real clusters sitting in `--json`.
+
+def test_pothole_in_click_choices_and_renderer():
+    """pothole appears in the positional Click choices (auto-derived from the
+    registry) and has a human-readable renderer wired into the dispatch
+    table — mirrors the same regression guard used for `verbosity`."""
+    from tokenjam.cli.cmd_optimize import _FINDING_RENDERERS, cmd_optimize
+
+    findings_param = next(
+        p for p in cmd_optimize.params if getattr(p, "name", None) == "findings"
+    )
+    assert "pothole" in findings_param.type.choices
+    assert "pothole" in _FINDING_RENDERERS
+
+
+def test_render_pothole_shows_clusters_without_error(tmp_path, capsys):
+    """The finding renders through the CLI dispatch path and surfaces the
+    cluster signature + occurrences + rung — not a generic empty state."""
+    from tokenjam.cli.cmd_optimize import _render_pothole
+
+    for i in range(MIN_RECURRING_SESSIONS):
+        _cwd_confusion_session(tmp_path, f"-Users-test-render{i}", f"render-{i}")
+    sessions = [(f"render-{i}", f"repo{i}") for i in range(MIN_RECURRING_SESSIONS)]
+    finding = analyze_potholes(sessions, projects_root=tmp_path, distill_enabled=False)
+    assert finding.clusters  # sanity: the analyzer actually found the cluster
+
+    for mode in ("api", "subscription", "local", "unknown"):
+        _render_pothole(finding, pricing_mode=mode, marker="①")
+    out = capsys.readouterr().out
+    assert "cwd_confusion" in out
+    assert f"{finding.clusters[0].occurrences}" in out
+    assert "rung 3" in out
+    assert "No candidates flagged" not in out
+
+
+def test_render_report_surfaces_pothole_clusters_instead_of_no_candidates(tmp_path, capsys):
+    """End-to-end regression: a report whose only finding is a
+    populated `pothole` cluster set must NOT fall through to the
+    cost-optimizer's generic "No candidates flagged" empty state."""
+    from tokenjam.cli.cmd_optimize import _render_report
+    from tokenjam.core.optimize.types import OptimizeReport, WindowSummary
+    from tokenjam.utils.time_parse import utcnow
+
+    for i in range(MIN_RECURRING_SESSIONS):
+        _cwd_confusion_session(tmp_path, f"-Users-test-e2e{i}", f"e2e-{i}")
+    sessions = [(f"e2e-{i}", f"repo{i}") for i in range(MIN_RECURRING_SESSIONS)]
+    finding = analyze_potholes(sessions, projects_root=tmp_path, distill_enabled=False)
+    assert finding.clusters
+
+    now = utcnow()
+    report = OptimizeReport(
+        window=WindowSummary(
+            since=now, until=now, days=365, sessions=len(sessions), spans=0,
+            total_tokens=100_000, total_cost_usd=0.0, thin_data=False,
+        ),
+        downgrade=None,
+        findings={"pothole": finding},
+    )
+    _render_report(report, agent=None, requested=["pothole"], pricing_mode="local")
+    out = capsys.readouterr().out
+    assert "No candidates flagged" not in out
+    assert "cwd_confusion" in out
+
+
+def test_render_report_surfaces_clusters_even_in_a_huge_token_window(tmp_path, capsys):
+    """Collapse variant: a pothole finding must surface its clusters in
+    full even when the window's total tokens are enormous (a heavy
+    `tj optimize pothole --since 365d` run). Potholes are recurring-failure
+    clusters, not a token-reclamation finding, so a huge window denominator
+    must NOT push them below DE_MINIMIS_SHARE and collapse them into the
+    "Minor findings — ~0.0% of window tokens" pointer — that hides the headline
+    self-improve signal exactly as the "No candidates flagged" empty state did.
+    """
+    from tokenjam.cli.cmd_optimize import _render_report
+    from tokenjam.core.optimize.types import OptimizeReport, WindowSummary
+    from tokenjam.utils.time_parse import utcnow
+
+    for i in range(MIN_RECURRING_SESSIONS):
+        _cwd_confusion_session(tmp_path, f"-Users-test-huge{i}", f"huge-{i}")
+    sessions = [(f"huge-{i}", f"repo{i}") for i in range(MIN_RECURRING_SESSIONS)]
+    finding = analyze_potholes(sessions, projects_root=tmp_path, distill_enabled=False)
+    assert finding.clusters
+    assert finding.estimated_recoverable_tokens  # a positive, rank-able estimate
+
+    now = utcnow()
+    report = OptimizeReport(
+        window=WindowSummary(
+            # 2B tokens — the cluster's occurrence×heuristic estimate is a ~0%
+            # share of this window, the exact condition that collapsed it.
+            since=now, until=now, days=365, sessions=len(sessions), spans=0,
+            total_tokens=2_000_000_000, total_cost_usd=0.0, thin_data=False,
+        ),
+        downgrade=None,
+        findings={"pothole": finding},
+    )
+    _render_report(report, agent=None, requested=["pothole"], pricing_mode="local")
+    out = capsys.readouterr().out
+    assert "cwd_confusion" in out                 # clusters surfaced in full
+    assert f"{finding.clusters[0].occurrences}" in out
+    assert "Minor findings" not in out            # NOT collapsed to the pointer
+    assert "of window tokens" not in out          # no de-minimis token framing
+    assert "No candidates flagged" not in out

--- a/tokenjam/cli/cmd_optimize.py
+++ b/tokenjam/cli/cmd_optimize.py
@@ -337,6 +337,17 @@ def cmd_optimize(
 # list instead of a numbered slot.
 DE_MINIMIS_SHARE = 0.01
 
+# Findings that must NEVER be collapsed into the "Minor findings" pointer by
+# token share. `pothole` is a recurring-failure-cluster finding, not a
+# token-reclamation one — its `estimated_recoverable_tokens` is a soft
+# occurrence×heuristic estimate for the Lens inbox, not a real fraction of the
+# window. Ranking it by that share let a heavy `--since 365d` window (huge
+# denominator) push real clusters below DE_MINIMIS_SHARE and hide them behind a
+# "~0.0% of window tokens" pointer — the same "nothing found" failure as the
+# empty-state bug. These findings always render in full (the `unranked`
+# bucket): their own detail when populated, their own empty-state when not.
+_ALWAYS_FULL_FINDINGS = {"pothole"}
+
 # Display labels for the "Minor findings" collapsed pointer list — must match
 # the header text each renderer prints in its numbered form.
 _MINOR_FINDING_LABELS = {
@@ -347,6 +358,7 @@ _MINOR_FINDING_LABELS = {
     "reuse":           "Reuse",
     "trim":            "Prompt bloat",
     "subagent":        "Subagent right-sizing",
+    "pothole":         "Pothole",
     "verbosity":       "Verbosity",
 }
 
@@ -403,7 +415,14 @@ def _rank_findings(
     for name, finding in (report.findings or {}).items():
         if name not in _FINDING_RENDERERS:
             continue
-        items.append((name, _reclaimable_share(finding, window_tokens)))
+        # A non-token finding (e.g. pothole) is forced into the unranked bucket
+        # so its clusters always render in full — a large window denominator
+        # must not collapse them into the de-minimis pointer list.
+        share = (
+            None if name in _ALWAYS_FULL_FINDINGS
+            else _reclaimable_share(finding, window_tokens)
+        )
+        items.append((name, share))
 
     items.sort(key=lambda item: (
         item[1] is None,
@@ -1461,6 +1480,49 @@ def _render_subagent(
     console.print(f"     [yellow]![/yellow] [italic]{finding.caveat}[/italic]")
 
 
+def _render_pothole(
+    finding, *, pricing_mode: str = "api", marker: str = "",
+) -> None:
+    """
+    Render the pothole finding — recurring failure clusters the self-improve
+    loop tracks (blockers an agent silently re-hits across sessions). Was
+    missing from _FINDING_RENDERERS entirely: the text view fell
+    through to the generic "No candidates flagged" empty state even when
+    --json carried dozens of clusters, because _rank_findings drops any
+    finding name not present in this dispatch table.
+    """
+    console.print(_finding_header(marker, "Pothole:"))
+    if not finding.clusters:
+        console.print(
+            f"     [dim]Scanned {finding.sessions_scanned} session"
+            f"{'s' if finding.sessions_scanned != 1 else ''}; "
+            f"no recurring failure clusters above threshold "
+            f"(≥3 sessions sharing a signature).[/dim]"
+        )
+        return
+
+    console.print(
+        f"     • [bold]{len(finding.clusters)}[/bold] pothole "
+        f"cluster{'s' if len(finding.clusters) != 1 else ''} found — "
+        f"recurring blockers this agent silently re-hits"
+    )
+    for c in finding.clusters[:10]:
+        console.print(
+            f"       [bold]{c.signature}[/bold]  "
+            f"{c.occurrences} occurrence{'s' if c.occurrences != 1 else ''} / "
+            f"{c.sessions} session{'s' if c.sessions != 1 else ''}  "
+            f"[dim](rung {c.rung})[/dim]"
+        )
+    if len(finding.clusters) > 10:
+        console.print(f"       [dim]… and {len(finding.clusters) - 10} more.[/dim]")
+    console.print(
+        "     [dim]Review + apply fixes in the Lens Review inbox, or see "
+        "full detail with [bold]tj optimize pothole --json[/bold].[/dim]"
+    )
+    if finding.caveat:
+        console.print(f"     [yellow]![/yellow] [italic]{finding.caveat}[/italic]")
+
+
 def _render_verbosity(
     finding, *, pricing_mode: str = "api", marker: str = "",
 ) -> None:
@@ -1527,5 +1589,6 @@ _FINDING_RENDERERS = {
     "reuse":        _render_reuse,
     "trim":         _render_prompt_bloat,
     "subagent":     _render_subagent,
+    "pothole":      _render_pothole,
     "verbosity":    _render_verbosity,
 }


### PR DESCRIPTION
`tj optimize pothole`'s text view was showing "No candidates flagged in this window" even when `--json` had real clusters in it.

## Root cause

`pothole` is registered in the analyzer registry (and shows up correctly in the CLI's positional `--findings` choices), but it was never added to `cmd_optimize`'s `_FINDING_RENDERERS` dispatch table. `_rank_findings` silently drops any finding name that isn't a key in that table, so the text-view renderer never saw the pothole data at all — it just fell through to the generic empty state.

Separately, `_rank_findings` ranks findings by their share of the window's total tokens, to decide whether they get a numbered slot or get collapsed into the "Minor findings" pointer list. Potholes aren't a token-reclamation finding (they're recurring failure clusters), so their `estimated_recoverable_tokens` is a soft heuristic estimate, not a real fraction of the window — a heavy window (e.g. `--since 365d`) could push real, actionable clusters below the de-minimis threshold and hide them behind a "~0.0% of window tokens" pointer, which is the same "nothing found" failure mode from a different angle.

## Fix

- Add `_render_pothole`: prints the cluster signature, occurrence/session counts, and rung for each pothole cluster (mirrors the existing renderers' style), plus the empty-state message when there are genuinely no clusters.
- Wire `"pothole": _render_pothole` into `_FINDING_RENDERERS`.
- Add `pothole` to `_ALWAYS_FULL_FINDINGS`, so `_rank_findings` puts it in the unranked bucket instead of computing a token share for it — it always renders in full rather than risking collapse into the minor-findings pointer.
- Add `"pothole"` to `_MINOR_FINDING_LABELS` for consistency with the other entries (harmless now that it's always-full, but keeps the table complete).

## Tests

- `test_pothole_in_click_choices_and_renderer` — pothole is in both the CLI's positional choices and the renderer dispatch table.
- `test_render_pothole_shows_clusters_without_error` — `_render_pothole` renders cluster signature/occurrences/rung across all four pricing modes.
- `test_render_report_surfaces_pothole_clusters_instead_of_no_candidates` — end-to-end: a report whose only finding is a populated pothole cluster set renders the clusters, not the empty state.
- `test_render_report_surfaces_clusters_even_in_a_huge_token_window` — regression for the de-minimis collapse variant: a 2B-token window doesn't hide the clusters behind "Minor findings" / "~0.0% of window tokens".

`pytest tests/unit/test_pothole.py -q` — 36 passed.

## Note on PR base

This targets `self-improve-loop` rather than `main` since the pothole analyzer itself only exists on that branch so far (see #482, still open against main).