### PR TITLE
docs: reposition public copy around cost [IN PROGRESS]

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,9 @@ ceiling), and `cache-recommend` (the Cache card's breakpoint-suggestion half). R
 
 `tj serve` runs Lens at `http://127.0.0.1:7391/`. It opens on the **Improve** lens: a **Review inbox**
 where the self-improve loop's proposed fixes land for your approval, a Dashboard that lands you on
-recurring mistakes and current health, and Status. Flip to the **Observe** lens for Traces, Cost,
+recurring mistakes and current health, and Status. The downsize, cache, and trim analyzers file
+advise-only proposals here too, with the realized dollar delta measured over your later calls once you
+mark one applied. Flip to the **Observe** lens for Traces, Cost,
 Analytics, Alerts, Drift, Optimize, and Budget. Plan-tier-aware, fully offline, no signup.
 
 <table>

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ telemetry for the failures they keep re-hitting, fixes them at the harness level
 config), and verifies the waste actually stopped. Works with Claude Code and Claude Agent SDK apps
 today, and with any SDK agent over OpenTelemetry (detect, advise, verify).
 
-Self-improvement is the mechanism; a lower bill is the point. TokenJam doesn't just show you what
+Finding and fixing repeated waste is the mechanism; a lower bill is the point. TokenJam doesn't just show you what
 your agents cost. It watches how your agent actually works, catches the blockers it silently re-hits
 session after session, and closes the loop: propose a fix, you approve it, it applies reversibly, and
 it checks whether the mistake actually stopped.
@@ -119,7 +119,7 @@ Point any OTLP exporter at `tj serve` and production agents flow in with zero co
 
 | You are | Run this | What you get |
 |---|---|---|
-| **Claude Code user** | `pipx install tokenjam && tj onboard --claude-code` | Backfills your last 30 days, wires a zero-token statusline, runs the self-improve loop plus all six analyzers + Lens |
+| **Claude Code user** | `pipx install tokenjam && tj onboard --claude-code` | Backfills your last 30 days, wires a zero-token statusline, runs the loop plus all six analyzers + Lens |
 | **Codex CLI user** | `pipx install tokenjam && tj onboard --codex` | Same onboarding flow, wired for Codex's session logs |
 | **Python SDK / API agent dev** | `pipx install tokenjam && tj onboard` + `@watch()` in your code ([Python SDK](docs/python-sdk.md)) | Live capture from your own agent process, plus the loop's detect, advise, and verify over your spans |
 | **Framework user** (LangChain / CrewAI / AutoGen) | `pip install tokenjam[langchain]` (or `[crewai]` / `[autogen]`) + one `patch_*()` call | Framework-level spans with no manual instrumentation |
@@ -227,7 +227,7 @@ Per-subagent cost breakdown; flags premium-model or over-contexted `Task` calls 
 </tr>
 </table>
 
-`tj optimize` (no args) runs every analyzer: the six above, plus `relearn` (the self-improve loop's
+`tj optimize` (no args) runs every analyzer: the six above, plus `relearn` (the loop's
 detector), `verbosity` (sessions whose output runs high versus the per-task-shape median),
 `summarize` (structure-aware prompt-file summarization candidates), `budget-projection` (projects your
 monthly run-rate against a configured `[budget.<provider>]` ceiling), and `cache-recommend` (the Cache
@@ -239,8 +239,10 @@ card's breakpoint-suggestion half). Run a subset with
 ## Lens: the local dashboard
 
 `tj serve` runs Lens at `http://127.0.0.1:7391/`. It opens on the **Improve** lens: a **Review inbox**
-where the self-improve loop's proposed fixes land for your approval, a Dashboard that lands you on
-recurring mistakes and current health, and Status. Flip to the **Observe** lens for Traces, Cost,
+where the loop's proposed fixes land for your approval, a Dashboard that lands you on
+recurring mistakes and current health, and Status. The downsize, cache, and trim analyzers file
+advise-only proposals here too, with the realized dollar delta measured over your later calls once you
+mark one applied. Flip to the **Observe** lens for Traces, Cost,
 Analytics, Alerts, Drift, Optimize, and Budget. Plan-tier-aware, fully offline, no signup.
 
 <table>
@@ -332,7 +334,7 @@ Bench reports measured pass-rate on a suite, never "certified" or "quality prese
 
 ## Roadmap
 
-**Shipped:** Self-improve loop (detect, propose, approve, apply, verify) on workspace agents, plus detect, advise, and verify for any OTel agent · Downsize · Cache · Script · Trim · Reuse · Subagent right-sizing · Claude Code + Codex onboarding · MCP server · Lens web UI (Improve + Observe lenses) · Backfill adapters (Langfuse, Helicone, OTLP) · Period comparison · Routing-config export · Read-only policy preview · Context & premium-model audits · Close-the-loop annotations/expectations · Prompt summarization (advisory) · Enforcement-plane proxy (suggest mode)
+**Shipped:** The fix-and-verify loop (detect, propose, approve, apply, verify) on workspace agents, plus detect, advise, and verify for any OTel agent · Downsize · Cache · Script · Trim · Reuse · Subagent right-sizing · Claude Code + Codex onboarding · MCP server · Lens web UI (Improve + Observe lenses) · Backfill adapters (Langfuse, Helicone, OTLP) · Period comparison · Routing-config export · Read-only policy preview · Context & premium-model audits · Close-the-loop annotations/expectations · Prompt summarization (advisory) · Enforcement-plane proxy (suggest mode)
 
 **Up next** (roughly):
 - [ ] Auto-apply for Agent SDK app repos, on the same human-gated ladder

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="docs/brand/tokenjam-repo-header.png" alt="TokenJam cuts what your AI agents cost by ending the mistakes they keep repeating: it finds the failures your agent re-hits, fixes them, and verifies the waste stopped. Runs 100% local." width="830">
+<img src="docs/brand/tokenjam-repo-header.png" alt="TokenJam: the self-improvement loop for AI agents. Finds the mistakes your agent keeps repeating, fixes them, and proves they stopped. Runs 100% local." width="830">
 
 [![CI](https://github.com/Metabuilder-Labs/tokenjam/actions/workflows/ci.yml/badge.svg)](https://github.com/Metabuilder-Labs/tokenjam/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/tokenjam?color=3d8eff&labelColor=0d1117)](https://pypi.org/project/tokenjam/)
@@ -16,17 +16,16 @@
 
 ---
 
-# Your agents waste up to 42% of a bad session's tokens repeating known mistakes. TokenJam gets those tokens back.
+# Your agents stop repeating their most expensive mistakes.
 
-TokenJam cuts what your AI agents cost by ending their repeated mistakes. It mines your agents' own
-telemetry for the failures they keep re-hitting, fixes them at the harness level (hooks, rules,
-config), and verifies the waste actually stopped. Works with Claude Code and Claude Agent SDK apps
-today, and with any SDK agent over OpenTelemetry (detect, advise, verify).
+TokenJam is the self-improvement loop for AI agents: it finds the mistakes your agent keeps
+repeating, fixes them, and proves they stopped. It starts with your Claude Code setup and scales to
+your production agents.
 
-Self-improvement is the mechanism; a lower bill is the point. TokenJam doesn't just show you what
-your agents cost. It watches how your agent actually works, catches the blockers it silently re-hits
-session after session, and closes the loop: propose a fix, you approve it, it applies reversibly, and
-it checks whether the mistake actually stopped.
+Think of it as **Sentry for coding-agent behavior, with the fix built in.** Not an observability
+tool, not a compressor, not a cost dashboard. It watches how your agent actually works, catches the
+blockers it silently re-hits session after session, and closes the loop: propose a fix, you approve
+it, it applies reversibly, and it checks whether the mistake actually stopped.
 
 ### See it in 30 seconds, no install
 
@@ -57,11 +56,10 @@ local DuckDB. Local-first, no cloud, no signup.
 
 Five stages, human-gated where it counts.
 
-1. **Detect.** TokenJam reads your agents' own telemetry, session transcripts for workspace agents
-   and OTel spans for everything else, then clusters the blockers your agent silently re-hits across
-   sessions: wrong-directory reads, edit-before-read, blocked sleep loops, stale-read races,
-   domain-blocked fetches. A pattern has to recur across at least three distinct sessions before it
-   becomes a **pothole**.
+1. **Detect.** TokenJam reads your Claude Code session transcripts and clusters the blockers your
+   agent silently re-hits across sessions: wrong-directory reads, edit-before-read, blocked sleep
+   loops, stale-read races, domain-blocked fetches. A pattern has to recur across at least three
+   distinct sessions before it becomes a **pothole**.
 2. **Propose.** For each pothole TokenJam drafts the lightest fix that could work, on a ladder:
    a **note** appended to your `CLAUDE.md`, then a **skill** (`.claude/skills/<name>/SKILL.md`), then
    a runtime **hook** (or wrapper / config) that catches the mistake as it happens.
@@ -70,8 +68,7 @@ Five stages, human-gated where it counts.
 4. **Apply.** Every write is reversible: snapshotted first, and git-committed when the target is
    tracked, so one revert undoes it. Enforcement rungs (hook / wrapper / config) ship **disabled by
    default** and **fail open**, so a fix can never block a working call or break your loop on
-   TokenJam's own bug. Agents with no workspace to write into skip this stage entirely: they get the
-   recommendation to apply themselves, and an optional eval-case artifact for your own tooling.
+   TokenJam's own bug.
 5. **Verify.** TokenJam watches later sessions and reports whether the recurrence actually dropped:
    improved, no change, or regressed. A weak fix (a note that is not landing) gets flagged for you to
    escalate to a stronger rung or revert.
@@ -85,7 +82,6 @@ apply, and watch verification), and `tj optimize pothole` prints the current pot
 ## What the loop is worth
 
 - **Up to 42% of a bad session's tokens** go to repeating known mistakes. TokenJam gets them back.
-  <br><sub>Worst measured session: 42.7% of its tokens (2.41M of 5.64M, replay-deduped) burned on recovery turns.</sub>
 - **About a dozen known-mistake re-hits a day** on a heavy multi-repo workspace.
 - **100% of busy-wait attempts blocked, deterministically.**
 - **Incident recovery 18.4% cheaper, measured on 90 days of real sessions.**
@@ -98,20 +94,16 @@ apply, and watch verification), and `tj optimize pothole` prints the current pot
 
 <div align="center"><img src="docs/assets/tokenjam-flow-band.svg" alt="TokenJam breaks into three stages: Observe (Lens), Optimize (Downsize, Cache, Trim, Script, Reuse), and Prove (Bench)." width="830"></div>
 
-The honest seam, so the pitch never lies:
+- **Claude Code, the wedge where the loop runs today.** Detect, propose, approve, apply, verify,
+  against your local Claude Code sessions. Fixes land as notes, skills, and hooks in your own config.
+  This is the surface that _applies_ fixes.
+- **SDK and production agents, over OpenTelemetry, the surface the loop scales to.** Today TokenJam
+  **observes** these: traces, real-time cost, drift baselines, sensitive-action alerts, budgets, and
+  the seven optimize analyzers, all read-only. It never touches your production request stream. The
+  Observe suite is where the improvement loop extends next.
 
-- **Workspace agents (Claude Code, Claude Agent SDK apps): the loop _applies_ the fix.** Detect,
-  propose, approve, apply, verify. Fixes land as notes, skills, and hooks in that repo's own
-  `.claude/` config, reversibly and human-gated. This is where a recurring mistake actually stops
-  costing you.
-- **Workspace-less agents over OpenTelemetry: the loop _advises and verifies_.** Same detector,
-  pointed at your production agents' spans: it clusters the recurring failures, hands you a
-  recommendation (config, prompt, or code) with no auto-apply path, and verifies whether the failure
-  signature's recurrence dropped after you deploy your own fix. It never touches your production
-  request stream. Alongside it runs the read-only Observe suite: traces, real-time cost, drift
-  baselines, sensitive-action alerts, budgets, and the optimize analyzers.
-
-Point any OTLP exporter at `tj serve` and production agents flow in with zero code.
+Point any OTLP exporter at `tj serve` and production agents flow in with zero code. The self-improve
+loop reads Claude Code transcripts; the SDK / OTel path is observe-only for now.
 
 ---
 
@@ -119,9 +111,9 @@ Point any OTLP exporter at `tj serve` and production agents flow in with zero co
 
 | You are | Run this | What you get |
 |---|---|---|
-| **Claude Code user** | `pipx install tokenjam && tj onboard --claude-code` | Backfills your last 30 days, wires a zero-token statusline, runs the self-improve loop plus all six analyzers + Lens |
+| **Claude Code user** | `pipx install tokenjam && tj onboard --claude-code` | Backfills your last 30 days, wires a zero-token statusline, runs the self-improve loop plus all seven analyzers + Lens |
 | **Codex CLI user** | `pipx install tokenjam && tj onboard --codex` | Same onboarding flow, wired for Codex's session logs |
-| **Python SDK / API agent dev** | `pipx install tokenjam && tj onboard` + `@watch()` in your code ([Python SDK](docs/python-sdk.md)) | Live capture from your own agent process, plus the loop's detect, advise, and verify over your spans |
+| **Python SDK / API agent dev** | `pipx install tokenjam && tj onboard` + `@watch()` in your code ([Python SDK](docs/python-sdk.md)) | Live capture from your own agent process, observed over the Observe suite |
 | **Framework user** (LangChain / CrewAI / AutoGen) | `pip install tokenjam[langchain]` (or `[crewai]` / `[autogen]`) + one `patch_*()` call | Framework-level spans with no manual instrumentation |
 | **Already on Langfuse / Helicone** | `tj backfill langfuse --source-url <url> --api-key <key>`<br>(swap `langfuse` → `helicone`, same flags) | One-time import of your existing traces into the local DB |
 | **Any OTel-emitting agent** | Point your OTLP exporter at `tj serve` (`http://127.0.0.1:7391/v1/traces`) | Zero-code ingestion: no SDK, no patch |
@@ -142,15 +134,13 @@ Run bare `tj` any time and it points you to the next best action.
 
 ---
 
-## Six analyzers + Lens. One install.
+## Seven analyzers + Lens. One install.
 
-Cutting cost is the whole point, and repeated mistakes are only one source of it. From the same
-telemetry, TokenJam surfaces cost-savings advisories across six more areas: read-only
-recommendations, each one the loop will wrap with a verified receipt as it extends. It reads the
-major agent runtimes, frameworks, providers, and observability tools, then brings them together in a
-local browser dashboard.
+The self-improve loop is the headline. Underneath it, TokenJam reads telemetry from the major agent
+runtimes, frameworks, providers, and observability tools and surfaces savings candidates across seven
+areas, then brings them together in a local browser dashboard.
 
-<div align="center"><img src="docs/assets/tokenjam-waste-grid.svg" alt="Where your tokens go: Expensive model (using Opus for a Haiku-level task) → downsize; Uncached repeats (sending the same base prompt 100s of times) → cache; Bloated prompts (re-sending the same long context every call) → trim; Oversized subagents (a Task call running premium-model or over-contexted) → subagent; Repeated planning (re-planning the same task every day) → reuse; Don't need an LLM (paying a model to do what code could) → script." width="830"></div>
+<div align="center"><img src="docs/assets/tokenjam-waste-grid.svg" alt="Where your tokens go: Expensive model (using Opus for a Haiku-level task) → downsize; Uncached repeats (sending the same base prompt 100s of times) → cache; Bloated prompts (re-sending the same long context every call) → trim; Verbose output (getting 500-word answers to yes/no questions) → verbosity; Repeated planning (re-planning the same task every day) → reuse; Don't need an LLM (paying a model to do what code could) → script." width="830"></div>
 
 <table>
 <tr>
@@ -225,11 +215,25 @@ Per-subagent cost breakdown; flags premium-model or over-contexted `Task` calls 
 
 </td>
 </tr>
+<tr>
+<td width="50%" valign="top">
+
+### Verbosity
+
+`tj optimize verbosity`
+
+Flags sessions whose output runs long against a per-(tool, task-shape) baseline. Predicted high-verbosity output, review before constraining a response.
+
+[Details →](docs/optimize/verbosity.md)
+
+</td>
+<td width="50%" valign="top">
+</td>
+</tr>
 </table>
 
-`tj optimize` (no args) runs every analyzer: the six above, plus `pothole` (the self-improve loop's
-detector), `verbosity` (sessions whose output runs high versus the per-task-shape median),
-`budget-projection` (projects your monthly run-rate against a configured `[budget.<provider>]`
+`tj optimize` (no args) runs every analyzer: the seven above, plus `pothole` (the self-improve loop's
+detector), `budget-projection` (projects your monthly run-rate against a configured `[budget.<provider>]`
 ceiling), and `cache-recommend` (the Cache card's breakpoint-suggestion half). Run a subset with
 `tj optimize downsize cache reuse`.
 
@@ -239,9 +243,7 @@ ceiling), and `cache-recommend` (the Cache card's breakpoint-suggestion half). R
 
 `tj serve` runs Lens at `http://127.0.0.1:7391/`. It opens on the **Improve** lens: a **Review inbox**
 where the self-improve loop's proposed fixes land for your approval, a Dashboard that lands you on
-recurring mistakes and current health, and Status. The downsize, cache, and trim analyzers file
-advise-only proposals here too, with the realized dollar delta measured over your later calls once you
-mark one applied. Flip to the **Observe** lens for Traces, Cost,
+recurring mistakes and current health, and Status. Flip to the **Observe** lens for Traces, Cost,
 Analytics, Alerts, Drift, Optimize, and Budget. Plan-tier-aware, fully offline, no signup.
 
 <table>
@@ -265,8 +267,8 @@ Analytics, Alerts, Drift, Optimize, and Budget. Plan-tier-aware, fully offline, 
 
 ## The Observe suite
 
-The loop applies fixes on workspace agents and advises plus verifies everywhere else. Around it,
-TokenJam is also a full, local-first observability stack for every agent you run.
+The self-improve loop closes on Claude Code. For every other agent, TokenJam is also a full,
+local-first observability stack, the read-only surface the loop scales to.
 
 - **Real-time cost tracking**: every LLM call priced as it happens
 - **Safety alerts**: 13 alert types, 6 channels (ntfy, Discord, Telegram, webhook, file, stdout)
@@ -333,10 +335,10 @@ Bench reports measured pass-rate on a suite, never "certified" or "quality prese
 
 ## Roadmap
 
-**Shipped:** Self-improve loop (detect, propose, approve, apply, verify) on workspace agents, plus detect, advise, and verify for any OTel agent · Downsize · Cache · Script · Trim · Reuse · Subagent right-sizing · Claude Code + Codex onboarding · MCP server · Lens web UI (Improve + Observe lenses) · Backfill adapters (Langfuse, Helicone, OTLP) · Period comparison · Routing-config export · Read-only policy preview · Context & premium-model audits · Close-the-loop annotations/expectations · Prompt summarization (advisory) · Enforcement-plane proxy (suggest mode)
+**Shipped:** Self-improve loop (detect, propose, approve, apply, verify, on Claude Code) · Downsize · Cache · Script · Trim · Reuse · Subagent right-sizing · Claude Code + Codex onboarding · MCP server · Lens web UI (Improve + Observe lenses) · Backfill adapters (Langfuse, Helicone, OTLP) · Period comparison · Routing-config export · Read-only policy preview · Context & premium-model audits · Close-the-loop annotations/expectations · Prompt summarization (advisory) · Enforcement-plane proxy (suggest mode)
 
 **Up next** (roughly):
-- [ ] Auto-apply for Agent SDK app repos, on the same human-gated ladder
+- [ ] Extend the self-improve loop to SDK / production agents over OTel
 - [ ] Continued Lens polish + per-product visual branding
 - [ ] `tj policy add | edit | apply`: unified rule surface (today: `tj policy list` / `tj policy decisions`)
 - [ ] `tj replay`: replay captured sessions against new model versions

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Point any OTLP exporter at `tj serve` and production agents flow in with zero co
 
 | You are | Run this | What you get |
 |---|---|---|
-| **Claude Code user** | `pipx install tokenjam && tj onboard --claude-code` | Backfills your last 30 days, wires a zero-token statusline, runs the loop plus all twelve analyzers + Lens |
+| **Claude Code user** | `pipx install tokenjam && tj onboard --claude-code` | Backfills your last 30 days, wires a zero-token statusline, runs the loop plus all thirteen analyzers + Lens |
 | **Codex CLI user** | `pipx install tokenjam && tj onboard --codex` | Same onboarding flow, wired for Codex's session logs |
 | **Python SDK / API agent dev** | `pipx install tokenjam && tj onboard` + `@watch()` in your code ([Python SDK](docs/python-sdk.md)) | Live capture from your own agent process, plus the loop's detect, advise, and verify over your spans |
 | **Framework user** (LangChain / CrewAI / AutoGen) | `pip install tokenjam[langchain]` (or `[crewai]` / `[autogen]`) + one `patch_*()` call | Framework-level spans with no manual instrumentation |
@@ -142,10 +142,10 @@ Run bare `tj` any time and it points you to the next best action.
 
 ---
 
-## Twelve analyzers + Lens. One install.
+## Thirteen analyzers + Lens. One install.
 
 Cutting cost is the whole point, and repeated mistakes are only one source of it. From the same
-telemetry, TokenJam surfaces cost-savings advisories across eleven more areas: read-only
+telemetry, TokenJam surfaces cost-savings advisories across twelve more areas: read-only
 recommendations, each one the loop will wrap with a verified receipt as it extends. It reads the
 major agent runtimes, frameworks, providers, and observability tools, then brings them together in a
 local browser dashboard.
@@ -227,13 +227,14 @@ Per-subagent cost breakdown; flags premium-model or over-contexted `Task` calls 
 </tr>
 </table>
 
-`tj optimize` (no args) runs all twelve analyzers: the six above, plus `relearn` (the loop's
+`tj optimize` (no args) runs all thirteen analyzers: the six above, plus `relearn` (the loop's
 detector), `verbosity` (sessions whose output runs high versus the per-task-shape median),
 `summarize` (structure-aware prompt-file summarization candidates), `deadweight` (MCP servers whose
 schemas load into every session and are never called), `budget-projection` (projects your
-monthly run-rate against a configured `[budget.<provider>]` ceiling), and `cache-recommend` (the Cache
-card's breakpoint-suggestion half). Each one is individually selectable; run a subset with
-`tj optimize downsize cache reuse`.
+monthly run-rate against a configured `[budget.<provider>]` ceiling), `cache-recommend` (the Cache
+card's breakpoint-suggestion half), and `resend` (token-weighted repeat-context share across turns,
+a structural resend measure independent of whether caching is enabled). Each one is individually
+selectable; run a subset with `tj optimize downsize cache reuse`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Point any OTLP exporter at `tj serve` and production agents flow in with zero co
 
 | You are | Run this | What you get |
 |---|---|---|
-| **Claude Code user** | `pipx install tokenjam && tj onboard --claude-code` | Backfills your last 30 days, wires a zero-token statusline, runs the loop plus all six analyzers + Lens |
+| **Claude Code user** | `pipx install tokenjam && tj onboard --claude-code` | Backfills your last 30 days, wires a zero-token statusline, runs the loop plus all twelve analyzers + Lens |
 | **Codex CLI user** | `pipx install tokenjam && tj onboard --codex` | Same onboarding flow, wired for Codex's session logs |
 | **Python SDK / API agent dev** | `pipx install tokenjam && tj onboard` + `@watch()` in your code ([Python SDK](docs/python-sdk.md)) | Live capture from your own agent process, plus the loop's detect, advise, and verify over your spans |
 | **Framework user** (LangChain / CrewAI / AutoGen) | `pip install tokenjam[langchain]` (or `[crewai]` / `[autogen]`) + one `patch_*()` call | Framework-level spans with no manual instrumentation |
@@ -142,10 +142,10 @@ Run bare `tj` any time and it points you to the next best action.
 
 ---
 
-## Six analyzers + Lens. One install.
+## Twelve analyzers + Lens. One install.
 
 Cutting cost is the whole point, and repeated mistakes are only one source of it. From the same
-telemetry, TokenJam surfaces cost-savings advisories across six more areas: read-only
+telemetry, TokenJam surfaces cost-savings advisories across eleven more areas: read-only
 recommendations, each one the loop will wrap with a verified receipt as it extends. It reads the
 major agent runtimes, frameworks, providers, and observability tools, then brings them together in a
 local browser dashboard.
@@ -227,11 +227,12 @@ Per-subagent cost breakdown; flags premium-model or over-contexted `Task` calls 
 </tr>
 </table>
 
-`tj optimize` (no args) runs every analyzer: the six above, plus `relearn` (the loop's
+`tj optimize` (no args) runs all twelve analyzers: the six above, plus `relearn` (the loop's
 detector), `verbosity` (sessions whose output runs high versus the per-task-shape median),
-`summarize` (structure-aware prompt-file summarization candidates), `budget-projection` (projects your
+`summarize` (structure-aware prompt-file summarization candidates), `deadweight` (MCP servers whose
+schemas load into every session and are never called), `budget-projection` (projects your
 monthly run-rate against a configured `[budget.<provider>]` ceiling), and `cache-recommend` (the Cache
-card's breakpoint-suggestion half). Run a subset with
+card's breakpoint-suggestion half). Each one is individually selectable; run a subset with
 `tj optimize downsize cache reuse`.
 
 ---

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ apply, and watch verification), and `tj optimize pothole` prints the current pot
   This is the surface that _applies_ fixes.
 - **SDK and production agents, over OpenTelemetry, the surface the loop scales to.** Today TokenJam
   **observes** these: traces, real-time cost, drift baselines, sensitive-action alerts, budgets, and
-  the seven optimize analyzers, all read-only. It never touches your production request stream. The
+  the six optimize analyzers, all read-only. It never touches your production request stream. The
   Observe suite is where the improvement loop extends next.
 
 Point any OTLP exporter at `tj serve` and production agents flow in with zero code. The self-improve
@@ -111,7 +111,7 @@ loop reads Claude Code transcripts; the SDK / OTel path is observe-only for now.
 
 | You are | Run this | What you get |
 |---|---|---|
-| **Claude Code user** | `pipx install tokenjam && tj onboard --claude-code` | Backfills your last 30 days, wires a zero-token statusline, runs the self-improve loop plus all seven analyzers + Lens |
+| **Claude Code user** | `pipx install tokenjam && tj onboard --claude-code` | Backfills your last 30 days, wires a zero-token statusline, runs the self-improve loop plus all six analyzers + Lens |
 | **Codex CLI user** | `pipx install tokenjam && tj onboard --codex` | Same onboarding flow, wired for Codex's session logs |
 | **Python SDK / API agent dev** | `pipx install tokenjam && tj onboard` + `@watch()` in your code ([Python SDK](docs/python-sdk.md)) | Live capture from your own agent process, observed over the Observe suite |
 | **Framework user** (LangChain / CrewAI / AutoGen) | `pip install tokenjam[langchain]` (or `[crewai]` / `[autogen]`) + one `patch_*()` call | Framework-level spans with no manual instrumentation |
@@ -134,13 +134,13 @@ Run bare `tj` any time and it points you to the next best action.
 
 ---
 
-## Seven analyzers + Lens. One install.
+## Six analyzers + Lens. One install.
 
 The self-improve loop is the headline. Underneath it, TokenJam reads telemetry from the major agent
-runtimes, frameworks, providers, and observability tools and surfaces savings candidates across seven
+runtimes, frameworks, providers, and observability tools and surfaces savings candidates across six
 areas, then brings them together in a local browser dashboard.
 
-<div align="center"><img src="docs/assets/tokenjam-waste-grid.svg" alt="Where your tokens go: Expensive model (using Opus for a Haiku-level task) → downsize; Uncached repeats (sending the same base prompt 100s of times) → cache; Bloated prompts (re-sending the same long context every call) → trim; Verbose output (getting 500-word answers to yes/no questions) → verbosity; Repeated planning (re-planning the same task every day) → reuse; Don't need an LLM (paying a model to do what code could) → script." width="830"></div>
+<div align="center"><img src="docs/assets/tokenjam-waste-grid.svg" alt="Where your tokens go: Expensive model (using Opus for a Haiku-level task) → downsize; Uncached repeats (sending the same base prompt 100s of times) → cache; Bloated prompts (re-sending the same long context every call) → trim; Oversized subagents (a Task call running premium-model or over-contexted) → subagent; Repeated planning (re-planning the same task every day) → reuse; Don't need an LLM (paying a model to do what code could) → script." width="830"></div>
 
 <table>
 <tr>
@@ -215,24 +215,9 @@ Per-subagent cost breakdown; flags premium-model or over-contexted `Task` calls 
 
 </td>
 </tr>
-<tr>
-<td width="50%" valign="top">
-
-### Verbosity
-
-`tj optimize verbosity`
-
-Flags sessions whose output runs long against a per-(tool, task-shape) baseline. Predicted high-verbosity output, review before constraining a response.
-
-[Details →](docs/optimize/verbosity.md)
-
-</td>
-<td width="50%" valign="top">
-</td>
-</tr>
 </table>
 
-`tj optimize` (no args) runs every analyzer: the seven above, plus `pothole` (the self-improve loop's
+`tj optimize` (no args) runs every analyzer: the six above, plus `pothole` (the self-improve loop's
 detector), `budget-projection` (projects your monthly run-rate against a configured `[budget.<provider>]`
 ceiling), and `cache-recommend` (the Cache card's breakpoint-suggestion half). Run a subset with
 `tj optimize downsize cache reuse`.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="docs/brand/tokenjam-repo-header.png" alt="TokenJam: the self-improvement loop for AI agents. Finds the mistakes your agent keeps repeating, fixes them, and proves they stopped. Runs 100% local." width="830">
+<img src="docs/brand/tokenjam-repo-header.png" alt="TokenJam cuts what your AI agents cost by ending the mistakes they keep repeating: it finds the failures your agent re-hits, fixes them, and verifies the waste stopped. Runs 100% local." width="830">
 
 [![CI](https://github.com/Metabuilder-Labs/tokenjam/actions/workflows/ci.yml/badge.svg)](https://github.com/Metabuilder-Labs/tokenjam/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/tokenjam?color=3d8eff&labelColor=0d1117)](https://pypi.org/project/tokenjam/)
@@ -16,16 +16,17 @@
 
 ---
 
-# Your agents stop repeating their most expensive mistakes.
+# Your agents waste up to 42% of a bad session's tokens repeating known mistakes. TokenJam gets those tokens back.
 
-TokenJam is the self-improvement loop for AI agents: it finds the mistakes your agent keeps
-repeating, fixes them, and proves they stopped. It starts with your Claude Code setup and scales to
-your production agents.
+TokenJam cuts what your AI agents cost by ending their repeated mistakes. It mines your agents' own
+telemetry for the failures they keep re-hitting, fixes them at the harness level (hooks, rules,
+config), and verifies the waste actually stopped. Works with Claude Code and Claude Agent SDK apps
+today, and with any SDK agent over OpenTelemetry (detect, advise, verify).
 
-Think of it as **Sentry for coding-agent behavior, with the fix built in.** Not an observability
-tool, not a compressor, not a cost dashboard. It watches how your agent actually works, catches the
-blockers it silently re-hits session after session, and closes the loop: propose a fix, you approve
-it, it applies reversibly, and it checks whether the mistake actually stopped.
+Self-improvement is the mechanism; a lower bill is the point. TokenJam doesn't just show you what
+your agents cost. It watches how your agent actually works, catches the blockers it silently re-hits
+session after session, and closes the loop: propose a fix, you approve it, it applies reversibly, and
+it checks whether the mistake actually stopped.
 
 ### See it in 30 seconds, no install
 
@@ -56,10 +57,11 @@ local DuckDB. Local-first, no cloud, no signup.
 
 Five stages, human-gated where it counts.
 
-1. **Detect.** TokenJam reads your Claude Code session transcripts and clusters the blockers your
-   agent silently re-hits across sessions: wrong-directory reads, edit-before-read, blocked sleep
-   loops, stale-read races, domain-blocked fetches. A pattern has to recur across at least three
-   distinct sessions before it becomes a **pothole**.
+1. **Detect.** TokenJam reads your agents' own telemetry, session transcripts for workspace agents
+   and OTel spans for everything else, then clusters the blockers your agent silently re-hits across
+   sessions: wrong-directory reads, edit-before-read, blocked sleep loops, stale-read races,
+   domain-blocked fetches. A pattern has to recur across at least three distinct sessions before it
+   becomes a **pothole**.
 2. **Propose.** For each pothole TokenJam drafts the lightest fix that could work, on a ladder:
    a **note** appended to your `CLAUDE.md`, then a **skill** (`.claude/skills/<name>/SKILL.md`), then
    a runtime **hook** (or wrapper / config) that catches the mistake as it happens.
@@ -68,7 +70,8 @@ Five stages, human-gated where it counts.
 4. **Apply.** Every write is reversible: snapshotted first, and git-committed when the target is
    tracked, so one revert undoes it. Enforcement rungs (hook / wrapper / config) ship **disabled by
    default** and **fail open**, so a fix can never block a working call or break your loop on
-   TokenJam's own bug.
+   TokenJam's own bug. Agents with no workspace to write into skip this stage entirely: they get the
+   recommendation to apply themselves, and an optional eval-case artifact for your own tooling.
 5. **Verify.** TokenJam watches later sessions and reports whether the recurrence actually dropped:
    improved, no change, or regressed. A weak fix (a note that is not landing) gets flagged for you to
    escalate to a stronger rung or revert.
@@ -82,6 +85,7 @@ apply, and watch verification), and `tj optimize pothole` prints the current pot
 ## What the loop is worth
 
 - **Up to 42% of a bad session's tokens** go to repeating known mistakes. TokenJam gets them back.
+  <br><sub>Worst measured session: 42.7% of its tokens (2.41M of 5.64M, replay-deduped) burned on recovery turns.</sub>
 - **About a dozen known-mistake re-hits a day** on a heavy multi-repo workspace.
 - **100% of busy-wait attempts blocked, deterministically.**
 - **Incident recovery 18.4% cheaper, measured on 90 days of real sessions.**
@@ -94,16 +98,20 @@ apply, and watch verification), and `tj optimize pothole` prints the current pot
 
 <div align="center"><img src="docs/assets/tokenjam-flow-band.svg" alt="TokenJam breaks into three stages: Observe (Lens), Optimize (Downsize, Cache, Trim, Script, Reuse), and Prove (Bench)." width="830"></div>
 
-- **Claude Code, the wedge where the loop runs today.** Detect, propose, approve, apply, verify,
-  against your local Claude Code sessions. Fixes land as notes, skills, and hooks in your own config.
-  This is the surface that _applies_ fixes.
-- **SDK and production agents, over OpenTelemetry, the surface the loop scales to.** Today TokenJam
-  **observes** these: traces, real-time cost, drift baselines, sensitive-action alerts, budgets, and
-  the six optimize analyzers, all read-only. It never touches your production request stream. The
-  Observe suite is where the improvement loop extends next.
+The honest seam, so the pitch never lies:
 
-Point any OTLP exporter at `tj serve` and production agents flow in with zero code. The self-improve
-loop reads Claude Code transcripts; the SDK / OTel path is observe-only for now.
+- **Workspace agents (Claude Code, Claude Agent SDK apps): the loop _applies_ the fix.** Detect,
+  propose, approve, apply, verify. Fixes land as notes, skills, and hooks in that repo's own
+  `.claude/` config, reversibly and human-gated. This is where a recurring mistake actually stops
+  costing you.
+- **Workspace-less agents over OpenTelemetry: the loop _advises and verifies_.** Same detector,
+  pointed at your production agents' spans: it clusters the recurring failures, hands you a
+  recommendation (config, prompt, or code) with no auto-apply path, and verifies whether the failure
+  signature's recurrence dropped after you deploy your own fix. It never touches your production
+  request stream. Alongside it runs the read-only Observe suite: traces, real-time cost, drift
+  baselines, sensitive-action alerts, budgets, and the optimize analyzers.
+
+Point any OTLP exporter at `tj serve` and production agents flow in with zero code.
 
 ---
 
@@ -113,7 +121,7 @@ loop reads Claude Code transcripts; the SDK / OTel path is observe-only for now.
 |---|---|---|
 | **Claude Code user** | `pipx install tokenjam && tj onboard --claude-code` | Backfills your last 30 days, wires a zero-token statusline, runs the self-improve loop plus all six analyzers + Lens |
 | **Codex CLI user** | `pipx install tokenjam && tj onboard --codex` | Same onboarding flow, wired for Codex's session logs |
-| **Python SDK / API agent dev** | `pipx install tokenjam && tj onboard` + `@watch()` in your code ([Python SDK](docs/python-sdk.md)) | Live capture from your own agent process, observed over the Observe suite |
+| **Python SDK / API agent dev** | `pipx install tokenjam && tj onboard` + `@watch()` in your code ([Python SDK](docs/python-sdk.md)) | Live capture from your own agent process, plus the loop's detect, advise, and verify over your spans |
 | **Framework user** (LangChain / CrewAI / AutoGen) | `pip install tokenjam[langchain]` (or `[crewai]` / `[autogen]`) + one `patch_*()` call | Framework-level spans with no manual instrumentation |
 | **Already on Langfuse / Helicone** | `tj backfill langfuse --source-url <url> --api-key <key>`<br>(swap `langfuse` → `helicone`, same flags) | One-time import of your existing traces into the local DB |
 | **Any OTel-emitting agent** | Point your OTLP exporter at `tj serve` (`http://127.0.0.1:7391/v1/traces`) | Zero-code ingestion: no SDK, no patch |
@@ -136,9 +144,11 @@ Run bare `tj` any time and it points you to the next best action.
 
 ## Six analyzers + Lens. One install.
 
-The self-improve loop is the headline. Underneath it, TokenJam reads telemetry from the major agent
-runtimes, frameworks, providers, and observability tools and surfaces savings candidates across six
-areas, then brings them together in a local browser dashboard.
+Cutting cost is the whole point, and repeated mistakes are only one source of it. From the same
+telemetry, TokenJam surfaces cost-savings advisories across six more areas: read-only
+recommendations, each one the loop will wrap with a verified receipt as it extends. It reads the
+major agent runtimes, frameworks, providers, and observability tools, then brings them together in a
+local browser dashboard.
 
 <div align="center"><img src="docs/assets/tokenjam-waste-grid.svg" alt="Where your tokens go: Expensive model (using Opus for a Haiku-level task) → downsize; Uncached repeats (sending the same base prompt 100s of times) → cache; Bloated prompts (re-sending the same long context every call) → trim; Oversized subagents (a Task call running premium-model or over-contexted) → subagent; Repeated planning (re-planning the same task every day) → reuse; Don't need an LLM (paying a model to do what code could) → script." width="830"></div>
 
@@ -218,7 +228,8 @@ Per-subagent cost breakdown; flags premium-model or over-contexted `Task` calls 
 </table>
 
 `tj optimize` (no args) runs every analyzer: the six above, plus `pothole` (the self-improve loop's
-detector), `budget-projection` (projects your monthly run-rate against a configured `[budget.<provider>]`
+detector), `verbosity` (sessions whose output runs high versus the per-task-shape median),
+`budget-projection` (projects your monthly run-rate against a configured `[budget.<provider>]`
 ceiling), and `cache-recommend` (the Cache card's breakpoint-suggestion half). Run a subset with
 `tj optimize downsize cache reuse`.
 
@@ -252,8 +263,8 @@ Analytics, Alerts, Drift, Optimize, and Budget. Plan-tier-aware, fully offline, 
 
 ## The Observe suite
 
-The self-improve loop closes on Claude Code. For every other agent, TokenJam is also a full,
-local-first observability stack, the read-only surface the loop scales to.
+The loop applies fixes on workspace agents and advises plus verifies everywhere else. Around it,
+TokenJam is also a full, local-first observability stack for every agent you run.
 
 - **Real-time cost tracking**: every LLM call priced as it happens
 - **Safety alerts**: 13 alert types, 6 channels (ntfy, Discord, Telegram, webhook, file, stdout)
@@ -320,10 +331,10 @@ Bench reports measured pass-rate on a suite, never "certified" or "quality prese
 
 ## Roadmap
 
-**Shipped:** Self-improve loop (detect, propose, approve, apply, verify, on Claude Code) · Downsize · Cache · Script · Trim · Reuse · Subagent right-sizing · Claude Code + Codex onboarding · MCP server · Lens web UI (Improve + Observe lenses) · Backfill adapters (Langfuse, Helicone, OTLP) · Period comparison · Routing-config export · Read-only policy preview · Context & premium-model audits · Close-the-loop annotations/expectations · Prompt summarization (advisory) · Enforcement-plane proxy (suggest mode)
+**Shipped:** Self-improve loop (detect, propose, approve, apply, verify) on workspace agents, plus detect, advise, and verify for any OTel agent · Downsize · Cache · Script · Trim · Reuse · Subagent right-sizing · Claude Code + Codex onboarding · MCP server · Lens web UI (Improve + Observe lenses) · Backfill adapters (Langfuse, Helicone, OTLP) · Period comparison · Routing-config export · Read-only policy preview · Context & premium-model audits · Close-the-loop annotations/expectations · Prompt summarization (advisory) · Enforcement-plane proxy (suggest mode)
 
 **Up next** (roughly):
-- [ ] Extend the self-improve loop to SDK / production agents over OTel
+- [ ] Auto-apply for Agent SDK app repos, on the same human-gated ladder
 - [ ] Continued Lens polish + per-product visual branding
 - [ ] `tj policy add | edit | apply`: unified rule surface (today: `tj policy list` / `tj policy decisions`)
 - [ ] `tj replay`: replay captured sessions against new model versions

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="docs/brand/tokenjam-repo-header.png" alt="TokenJam cuts what your AI agents cost by ending the mistakes they keep repeating: it finds the failures your agent re-hits, fixes them, and verifies the waste stopped. Runs 100% local." width="830">
+<img src="docs/brand/tokenjam-repo-header.png" alt="TokenJam cuts what your AI agents cost by ending the mistakes they keep repeating: it finds the failures your agent re-hits and fixes them, reversibly and human-gated. Runs 100% local." width="830">
 
 [![CI](https://github.com/Metabuilder-Labs/tokenjam/actions/workflows/ci.yml/badge.svg)](https://github.com/Metabuilder-Labs/tokenjam/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/tokenjam?color=3d8eff&labelColor=0d1117)](https://pypi.org/project/tokenjam/)
@@ -19,23 +19,23 @@
 # Your agents waste up to 42% of a bad session's tokens repeating known mistakes. TokenJam gets those tokens back.
 
 TokenJam cuts what your AI agents cost by ending their repeated mistakes. It mines your agents' own
-telemetry for the failures they keep re-hitting, fixes them at the harness level (hooks, rules,
-config), and verifies the waste actually stopped. Works with Claude Code and Claude Agent SDK apps
-today, and with any SDK agent over OpenTelemetry (detect, advise, verify).
+telemetry for the failures they keep re-hitting, and fixes them at the harness level (hooks, rules,
+config). Works with Claude Code and Claude Agent SDK apps today, and with any SDK agent over
+OpenTelemetry (detect, advise).
 
 Finding and fixing repeated waste is the mechanism; a lower bill is the point. TokenJam doesn't just show you what
 your agents cost. It watches how your agent actually works, catches the blockers it silently re-hits
-session after session, and closes the loop: propose a fix, you approve it, it applies reversibly, and
-it checks whether the mistake actually stopped.
+session after session, and closes the loop: propose a fix, you approve it, it applies reversibly.
 
 ### See it in 30 seconds, no install
 
 ```bash
-npx tokenjam        # a read-only report of your agent's recurring mistakes. nothing installed, nothing kept
+npx tokenjam        # a read-only report of where your Claude Code quota goes. nothing installed, nothing kept
 ```
 
-Bare `npx tokenjam` reads the Claude Code logs you already have and prints the recurring mistakes your
-agent keeps repeating. When you want the loop that fixes them, onboard:
+Bare `npx tokenjam` reads the Claude Code logs you already have and prints where your quota actually
+goes (re-reads vs. net-new work) plus a session timeline. When you want the loop that finds and fixes
+recurring mistakes, onboard:
 
 ```bash
 npx tokenjam onboard   # or: pipx install tokenjam && tj onboard
@@ -55,7 +55,7 @@ local DuckDB. Local-first, no cloud, no signup.
 
 ## How the loop works
 
-Five stages, human-gated where it counts.
+Four stages, human-gated where it counts.
 
 1. **Detect.** TokenJam reads your agents' own telemetry, session transcripts for workspace agents
    and OTel spans for everything else, then clusters the blockers your agent silently re-hits across
@@ -72,13 +72,12 @@ Five stages, human-gated where it counts.
    default** and **fail open**, so a fix can never block a working call or break your loop on
    TokenJam's own bug. Agents with no workspace to write into skip this stage entirely: they get the
    recommendation to apply themselves, and an optional eval-case artifact for your own tooling.
-5. **Verify.** TokenJam watches later sessions and reports whether the recurrence actually dropped:
-   improved, no change, or regressed. A weak fix (a note that is not landing) gets flagged for you to
-   escalate to a stronger rung or revert.
 
 You drive this from three places, no new command to learn: `tj onboard` surfaces your first fix, the
-`tj serve` daemon keeps the detector warm and serves the **Review inbox** in Lens (where you approve,
-apply, and watch verification), and `tj optimize relearn` prints the current findings from the CLI.
+`tj serve` daemon keeps the detector warm and serves the **Review inbox** in Lens (where you approve
+and apply), and `tj optimize relearn` prints the current findings from the CLI. Want a record of
+whether a fix actually helped? `tj loop` lets you leave a manual note and verdict on later sessions
+(see [The Observe suite](#the-observe-suite)); TokenJam does not auto-verify recurrence for you today.
 
 ---
 
@@ -87,7 +86,7 @@ apply, and watch verification), and `tj optimize relearn` prints the current fin
 - **Up to 42% of a bad session's tokens** go to repeating known mistakes. TokenJam gets them back.
   <br><sub>Worst measured session: 42.7% of its tokens (2.41M of 5.64M, replay-deduped) burned on recovery turns.</sub>
 - **About a dozen known-mistake re-hits a day** on a heavy multi-repo workspace.
-- **100% of busy-wait attempts blocked, deterministically.**
+- **100% of measured sleep-chain busy-wait attempts blocked, deterministically.**
 - **Incident recovery 18.4% cheaper, measured on 90 days of real sessions.**
 - **On one workspace, TokenJam rediscovered 8 of 9 lessons the team had learned the hard way, plus 8
   nobody had noticed.**
@@ -101,13 +100,12 @@ apply, and watch verification), and `tj optimize relearn` prints the current fin
 The honest seam, so the pitch never lies:
 
 - **Workspace agents (Claude Code, Claude Agent SDK apps): the loop _applies_ the fix.** Detect,
-  propose, approve, apply, verify. Fixes land as notes, skills, and hooks in that repo's own
+  propose, approve, apply. Fixes land as notes, skills, and hooks in that repo's own
   `.claude/` config, reversibly and human-gated. This is where a recurring mistake actually stops
   costing you.
-- **Workspace-less agents over OpenTelemetry: the loop _advises and verifies_.** Same detector,
-  pointed at your production agents' spans: it clusters the recurring failures, hands you a
-  recommendation (config, prompt, or code) with no auto-apply path, and verifies whether the failure
-  signature's recurrence dropped after you deploy your own fix. It never touches your production
+- **Workspace-less agents over OpenTelemetry: the loop _advises_.** Same detector,
+  pointed at your production agents' spans: it clusters the recurring failures and hands you a
+  recommendation (config, prompt, or code) with no auto-apply path. It never touches your production
   request stream. Alongside it runs the read-only Observe suite: traces, real-time cost, drift
   baselines, sensitive-action alerts, budgets, and the optimize analyzers.
 
@@ -121,7 +119,7 @@ Point any OTLP exporter at `tj serve` and production agents flow in with zero co
 |---|---|---|
 | **Claude Code user** | `pipx install tokenjam && tj onboard --claude-code` | Backfills your last 30 days, wires a zero-token statusline, runs the loop plus all thirteen analyzers + Lens |
 | **Codex CLI user** | `pipx install tokenjam && tj onboard --codex` | Same onboarding flow, wired for Codex's session logs |
-| **Python SDK / API agent dev** | `pipx install tokenjam && tj onboard` + `@watch()` in your code ([Python SDK](docs/python-sdk.md)) | Live capture from your own agent process, plus the loop's detect, advise, and verify over your spans |
+| **Python SDK / API agent dev** | `pipx install tokenjam && tj onboard` + `@watch()` in your code ([Python SDK](docs/python-sdk.md)) | Live capture from your own agent process, plus the loop's detect and advise over your spans |
 | **Framework user** (LangChain / CrewAI / AutoGen) | `pip install tokenjam[langchain]` (or `[crewai]` / `[autogen]`) + one `patch_*()` call | Framework-level spans with no manual instrumentation |
 | **Already on Langfuse / Helicone** | `tj backfill langfuse --source-url <url> --api-key <key>`<br>(swap `langfuse` → `helicone`, same flags) | One-time import of your existing traces into the local DB |
 | **Any OTel-emitting agent** | Point your OTLP exporter at `tj serve` (`http://127.0.0.1:7391/v1/traces`) | Zero-code ingestion: no SDK, no patch |
@@ -146,7 +144,7 @@ Run bare `tj` any time and it points you to the next best action.
 
 Cutting cost is the whole point, and repeated mistakes are only one source of it. From the same
 telemetry, TokenJam surfaces cost-savings advisories across twelve more areas: read-only
-recommendations, each one the loop will wrap with a verified receipt as it extends. It reads the
+recommendations today, with apply support extending to more of them over time. It reads the
 major agent runtimes, frameworks, providers, and observability tools, then brings them together in a
 local browser dashboard.
 
@@ -243,8 +241,8 @@ selectable; run a subset with `tj optimize downsize cache reuse`.
 `tj serve` runs Lens at `http://127.0.0.1:7391/`. It opens on the **Improve** lens: a **Review inbox**
 where the loop's proposed fixes land for your approval, a Dashboard that lands you on
 recurring mistakes and current health, and Status. The downsize, cache, and trim analyzers file
-advise-only proposals here too, with the realized dollar delta measured over your later calls once you
-mark one applied. Flip to the **Observe** lens for Traces, Cost,
+advise-only proposals here too; marking one applied records when you made the change, for your own
+tracking. Flip to the **Observe** lens for Traces, Cost,
 Analytics, Alerts, Drift, Optimize, and Budget. Plan-tier-aware, fully offline, no signup.
 
 <table>
@@ -268,7 +266,7 @@ Analytics, Alerts, Drift, Optimize, and Budget. Plan-tier-aware, fully offline, 
 
 ## The Observe suite
 
-The loop applies fixes on workspace agents and advises plus verifies everywhere else. Around it,
+The loop applies fixes on workspace agents and advises everywhere else. Around it,
 TokenJam is also a full, local-first observability stack for every agent you run.
 
 - **Real-time cost tracking**: every LLM call priced as it happens
@@ -336,7 +334,7 @@ Bench reports measured pass-rate on a suite, never "certified" or "quality prese
 
 ## Roadmap
 
-**Shipped:** The fix-and-verify loop (detect, propose, approve, apply, verify) on workspace agents, plus detect, advise, and verify for any OTel agent · Downsize · Cache · Script · Trim · Reuse · Subagent right-sizing · Claude Code + Codex onboarding · MCP server · Lens web UI (Improve + Observe lenses) · Backfill adapters (Langfuse, Helicone, OTLP) · Period comparison · Routing-config export · Read-only policy preview · Context & premium-model audits · Close-the-loop annotations/expectations · Prompt summarization (advisory) · Enforcement-plane proxy (suggest mode)
+**Shipped:** The detect-propose-approve-apply loop on workspace agents, plus detect and advise for any OTel agent · Downsize · Cache · Script · Trim · Reuse · Subagent right-sizing · Claude Code + Codex onboarding · MCP server · Lens web UI (Improve + Observe lenses) · Backfill adapters (Langfuse, Helicone, OTLP) · Period comparison · Routing-config export · Read-only policy preview · Context & premium-model audits · Close-the-loop annotations/expectations · Prompt summarization (advisory) · Enforcement-plane proxy (suggest mode)
 
 **Up next** (roughly):
 - [ ] Auto-apply for Agent SDK app repos, on the same human-gated ladder

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 <div align="center">
 
-<img src="docs/brand/tokenjam-repo-header.png" alt="TokenJam: token efficiency for AI agents. Reads your agent's telemetry, finds the waste, runs 100% local." width="830">
-
-TokenJam reads your agent's telemetry and tells you when to downsize, when to trim prompts, what to cache, what to script, and what plans you've already paid to figure out. It then shows it all in a local browser dashboard. Runs entirely on your machine.
+<img src="docs/brand/tokenjam-repo-header.png" alt="TokenJam cuts what your AI agents cost by ending the mistakes they keep repeating: it finds the failures your agent re-hits, fixes them, and verifies the waste stopped. Runs 100% local." width="830">
 
 [![CI](https://github.com/Metabuilder-Labs/tokenjam/actions/workflows/ci.yml/badge.svg)](https://github.com/Metabuilder-Labs/tokenjam/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/tokenjam?color=3d8eff&labelColor=0d1117)](https://pypi.org/project/tokenjam/)
@@ -14,44 +12,106 @@ TokenJam reads your agent's telemetry and tells you when to downsize, when to tr
 
 **No cloud · No signup · No vendor lock-in**
 
-
-<div align="center"><img src="docs/assets/tokenjam-flow-band.svg" alt="Your agents (Claude Code, Codex, Cursor) feed TokenJam, which breaks into three stages: Observe (Lens), Optimize (Downsize, Cache, Trim, Script, Reuse), and Prove (Bench)." width="830"></div>
-<div align="center"><img src="docs/assets/tokenjam-waste-grid.svg" alt="Where your tokens go: Expensive model (using Opus for a Haiku-level task) → downsize; Uncached repeats (sending the same base prompt 100s of times) → cache; Bloated prompts (re-sending the same long context every call) → trim; Verbose output (getting 500-word answers to yes/no questions) → verbosity; Repeated planning (re-planning the same task every day) → reuse; Don't need an LLM (paying a model to do what code could) → script." width="830"></div>
-
-
-
 </div>
 
 ---
 
-## Get started
+# Your agents waste up to 42% of a bad session's tokens repeating known mistakes. TokenJam gets those tokens back.
 
-TokenJam ingests telemetry data about your agents from a multitude of sources and provides you a quick and easy way to visualize and optimize cost so that you get the most out of the tokens you pay for.
+TokenJam cuts what your AI agents cost by ending their repeated mistakes. It mines your agents' own
+telemetry for the failures they keep re-hitting, fixes them at the harness level (hooks, rules,
+config), and verifies the waste actually stopped. Works with Claude Code and Claude Agent SDK apps
+today, and with any SDK agent over OpenTelemetry (detect, advise, verify).
 
-One command sets up live capture, all six analyzers, Lens (the local dashboard), and the zero-token statusline:
+Self-improvement is the mechanism; a lower bill is the point. TokenJam doesn't just show you what
+your agents cost. It watches how your agent actually works, catches the blockers it silently re-hits
+session after session, and closes the loop: propose a fix, you approve it, it applies reversibly, and
+it checks whether the mistake actually stopped.
+
+### See it in 30 seconds, no install
+
+```bash
+npx tokenjam        # a read-only report of your agent's recurring mistakes. nothing installed, nothing kept
+```
+
+Bare `npx tokenjam` reads the Claude Code logs you already have and prints the potholes your agent
+keeps driving into. When you want the loop that fixes them, onboard:
 
 ```bash
 npx tokenjam onboard   # or: pipx install tokenjam && tj onboard
 ```
 
-`tj onboard` asks how you use AI agents (Claude Code, Codex, or your own SDK/API agents) and wires the right path; under npx it first offers to make itself a permanent install. For Claude Code and Codex that means backfilling your recent history plus the statusline and hooks; restart and you're live. Then run:
+`tj onboard` asks how you run AI agents (Claude Code, Codex, or your own SDK / API agents) and wires
+the right path. For Claude Code and Codex it backfills your recent history, installs the statusline
+and hooks, and ends by showing the mistakes your agent keeps making, then offers to enable your first
+fix. Under `npx` it first offers to make itself a permanent install.
 
-```bash
-tj optimize          # cost-saving candidates from your actual usage
-tj serve             # open the dashboard at http://127.0.0.1:7391/
-```
-
-The statusline is **zero-token**; `tj statusline` runs out-of-band each turn (no model quota) and shows this session's re-read share with a `/compact` nudge: `◆ Opus 4.8  2.4M tok  🕳️ re-read 95%  → /compact to reclaim quota`. It does **not** add an in-loop MCP server (that's an SDK / API surface; an MCP would tax every turn).
-
-Run bare `tj` any time and it points you to the next best action (`tj status`, `tj tokenmaxx`, `tj optimize`, or `tj serve`).
-
-**Just looking?** `npx tokenjam` prints a 15-second read-only report over the logs you already have: no install, nothing kept.
-
-Building your own agent with the SDK: install *in your project* (`pip install tokenjam` + `tj onboard`); see the table below.
+TokenJam ingests agent telemetry from many sources (Claude Code sessions, any OTel source) into a
+local DuckDB. Local-first, no cloud, no signup.
 
 <sub>`npx tokenjam` and `uvx tokenjam` launch the Python CLI via `uvx`/`pipx` under the hood; see [docs/installation.md](docs/installation.md) for the runner requirements and the full install matrix.</sub>
 
-<div align="center"><img src="docs/assets/tokenjam-token-flow.png" alt="Token flow: telemetry from Claude Code, Codex, Google, AWS, the Python and TypeScript SDKs, LangChain/CrewAI, and OTLP/Langfuse flows into tokenjam, which decomposes where every token goes: 94% re-reads of history and context, 5.1% tool output, 0.9% net-new work, measured over a 61-session history" width="830"></div>
+---
+
+## How the loop works
+
+Five stages, human-gated where it counts.
+
+1. **Detect.** TokenJam reads your agents' own telemetry, session transcripts for workspace agents
+   and OTel spans for everything else, then clusters the blockers your agent silently re-hits across
+   sessions: wrong-directory reads, edit-before-read, blocked sleep loops, stale-read races,
+   domain-blocked fetches. A pattern has to recur across at least three distinct sessions before it
+   becomes a **pothole**.
+2. **Propose.** For each pothole TokenJam drafts the lightest fix that could work, on a ladder:
+   a **note** appended to your `CLAUDE.md`, then a **skill** (`.claude/skills/<name>/SKILL.md`), then
+   a runtime **hook** (or wrapper / config) that catches the mistake as it happens.
+3. **Approve.** Nothing is written until you say so. You review the evidence (the repro sessions) and
+   the exact diff first.
+4. **Apply.** Every write is reversible: snapshotted first, and git-committed when the target is
+   tracked, so one revert undoes it. Enforcement rungs (hook / wrapper / config) ship **disabled by
+   default** and **fail open**, so a fix can never block a working call or break your loop on
+   TokenJam's own bug. Agents with no workspace to write into skip this stage entirely: they get the
+   recommendation to apply themselves, and an optional eval-case artifact for your own tooling.
+5. **Verify.** TokenJam watches later sessions and reports whether the recurrence actually dropped:
+   improved, no change, or regressed. A weak fix (a note that is not landing) gets flagged for you to
+   escalate to a stronger rung or revert.
+
+You drive this from three places, no new command to learn: `tj onboard` surfaces your first fix, the
+`tj serve` daemon keeps the detector warm and serves the **Review inbox** in Lens (where you approve,
+apply, and watch verification), and `tj optimize pothole` prints the current potholes from the CLI.
+
+---
+
+## What the loop is worth
+
+- **Up to 42% of a bad session's tokens** go to repeating known mistakes. TokenJam gets them back.
+  <br><sub>Worst measured session: 42.7% of its tokens (2.41M of 5.64M, replay-deduped) burned on recovery turns.</sub>
+- **About a dozen known-mistake re-hits a day** on a heavy multi-repo workspace.
+- **100% of busy-wait attempts blocked, deterministically.**
+- **Incident recovery 18.4% cheaper, measured on 90 days of real sessions.**
+- **On one workspace, TokenJam rediscovered 8 of 9 lessons the team had learned the hard way, plus 8
+  nobody had noticed.**
+
+---
+
+## Two surfaces, one product
+
+<div align="center"><img src="docs/assets/tokenjam-flow-band.svg" alt="TokenJam breaks into three stages: Observe (Lens), Optimize (Downsize, Cache, Trim, Script, Reuse), and Prove (Bench)." width="830"></div>
+
+The honest seam, so the pitch never lies:
+
+- **Workspace agents (Claude Code, Claude Agent SDK apps): the loop _applies_ the fix.** Detect,
+  propose, approve, apply, verify. Fixes land as notes, skills, and hooks in that repo's own
+  `.claude/` config, reversibly and human-gated. This is where a recurring mistake actually stops
+  costing you.
+- **Workspace-less agents over OpenTelemetry: the loop _advises and verifies_.** Same detector,
+  pointed at your production agents' spans: it clusters the recurring failures, hands you a
+  recommendation (config, prompt, or code) with no auto-apply path, and verifies whether the failure
+  signature's recurrence dropped after you deploy your own fix. It never touches your production
+  request stream. Alongside it runs the read-only Observe suite: traces, real-time cost, drift
+  baselines, sensitive-action alerts, budgets, and the optimize analyzers.
+
+Point any OTLP exporter at `tj serve` and production agents flow in with zero code.
 
 ---
 
@@ -59,25 +119,38 @@ Building your own agent with the SDK: install *in your project* (`pip install to
 
 | You are | Run this | What you get |
 |---|---|---|
-| **Claude Code user** | `pipx install tokenjam && tj onboard --claude-code` | Auto-backfills your last 30 days, wires a zero-token statusline, unlocks all seven analyzers + Lens |
+| **Claude Code user** | `pipx install tokenjam && tj onboard --claude-code` | Backfills your last 30 days, wires a zero-token statusline, runs the self-improve loop plus all six analyzers + Lens |
 | **Codex CLI user** | `pipx install tokenjam && tj onboard --codex` | Same onboarding flow, wired for Codex's session logs |
-| **Python SDK / API agent dev** | `pipx install tokenjam && tj onboard` + `@watch()` in your code ([Python SDK](docs/python-sdk.md)) | Live capture from your own agent process, no CLI-specific backfill |
+| **Python SDK / API agent dev** | `pipx install tokenjam && tj onboard` + `@watch()` in your code ([Python SDK](docs/python-sdk.md)) | Live capture from your own agent process, plus the loop's detect, advise, and verify over your spans |
 | **Framework user** (LangChain / CrewAI / AutoGen) | `pip install tokenjam[langchain]` (or `[crewai]` / `[autogen]`) + one `patch_*()` call | Framework-level spans with no manual instrumentation |
 | **Already on Langfuse / Helicone** | `tj backfill langfuse --source-url <url> --api-key <key>`<br>(swap `langfuse` → `helicone`, same flags) | One-time import of your existing traces into the local DB |
 | **Any OTel-emitting agent** | Point your OTLP exporter at `tj serve` (`http://127.0.0.1:7391/v1/traces`) | Zero-code ingestion: no SDK, no patch |
 
-<sub>The `--claude-code` / `--codex` flags just pre-answer the wizard's first question; bare `tj onboard` asks.</sub>
+<sub>The `--claude-code` / `--codex` flags just pre-answer the wizard's first question; bare `tj onboard` asks. `pipx` (not `pip`) sidesteps PEP 668 on Homebrew / Debian / Ubuntu Python.</sub>
 
-LlamaIndex and the OpenAI Agents SDK ship their own native OTel support; point their exporter at `tj serve` rather than installing an extra. Full matrix: [docs/framework-support.md](docs/framework-support.md).
+LlamaIndex and the OpenAI Agents SDK ship their own native OTel support; point their exporter at
+`tj serve` rather than installing an extra. Full matrix: [docs/framework-support.md](docs/framework-support.md).
 
 A single page walks every path, each ending with a verify step: see
 [docs/getting-started.md](docs/getting-started.md).
 
+The statusline is **zero-token**: `tj statusline` runs out-of-band each turn (it spends no model
+tokens) and shows this session's re-read share with a `/compact` nudge. It does **not** add an in-loop
+MCP server (that is an SDK / API surface; an in-loop MCP would tax every turn).
+
+Run bare `tj` any time and it points you to the next best action.
+
 ---
 
-## Seven analyzers + Lens. One install.
+## Six analyzers + Lens. One install.
 
-TokenJam reads telemetry from the major agent runtimes, frameworks, providers, and observability tools and surfaces savings across seven areas. It then brings them together in a local browser dashboard.
+Cutting cost is the whole point, and repeated mistakes are only one source of it. From the same
+telemetry, TokenJam surfaces cost-savings advisories across six more areas: read-only
+recommendations, each one the loop will wrap with a verified receipt as it extends. It reads the
+major agent runtimes, frameworks, providers, and observability tools, then brings them together in a
+local browser dashboard.
+
+<div align="center"><img src="docs/assets/tokenjam-waste-grid.svg" alt="Where your tokens go: Expensive model (using Opus for a Haiku-level task) → downsize; Uncached repeats (sending the same base prompt 100s of times) → cache; Bloated prompts (re-sending the same long context every call) → trim; Oversized subagents (a Task call running premium-model or over-contexted) → subagent; Repeated planning (re-planning the same task every day) → reuse; Don't need an LLM (paying a model to do what code could) → script." width="830"></div>
 
 <table>
 <tr>
@@ -152,30 +225,22 @@ Per-subagent cost breakdown; flags premium-model or over-contexted `Task` calls 
 
 </td>
 </tr>
-<tr>
-<td width="50%" valign="top">
-
-### Verbosity
-
-`tj optimize verbosity`
-
-Flags sessions whose output runs long against a per-(tool, task-shape) baseline. Predicted high-verbosity output — review before constraining a response.
-
-[Details →](docs/optimize/verbosity.md)
-
-</td>
-<td width="50%" valign="top">
-</td>
-</tr>
 </table>
 
-`tj optimize` (no args) runs every analyzer: the seven above, plus `budget-projection` (projects your monthly run-rate against a configured `[budget.<provider>]` ceiling; powers Lens's Budget screen) and `cache-recommend` (the Cache card's breakpoint-suggestion half, above). Run a subset with `tj optimize downsize cache reuse`. Lens brings it all together: see the dashboard below.
+`tj optimize` (no args) runs every analyzer: the six above, plus `pothole` (the self-improve loop's
+detector), `verbosity` (sessions whose output runs high versus the per-task-shape median),
+`budget-projection` (projects your monthly run-rate against a configured `[budget.<provider>]`
+ceiling), and `cache-recommend` (the Cache card's breakpoint-suggestion half). Run a subset with
+`tj optimize downsize cache reuse`.
 
 ---
 
 ## Lens: the local dashboard
 
-`tj serve` runs Lens at `http://127.0.0.1:7391/`: a **Dashboard** that lands you on recoverable waste and current health, with an embedded explorer to slice your usage any way (metric × dimension × chart); plus Status, Traces, Cost, Analytics, Alerts, Drift, Optimize, and Budget screens. Plan-tier-aware, fully offline, no signup.
+`tj serve` runs Lens at `http://127.0.0.1:7391/`. It opens on the **Improve** lens: a **Review inbox**
+where the self-improve loop's proposed fixes land for your approval, a Dashboard that lands you on
+recurring mistakes and current health, and Status. Flip to the **Observe** lens for Traces, Cost,
+Analytics, Alerts, Drift, Optimize, and Budget. Plan-tier-aware, fully offline, no signup.
 
 <table>
 <tr>
@@ -196,21 +261,29 @@ Flags sessions whose output runs long against a per-(tool, task-shape) baseline.
 
 ---
 
-## Beyond optimization
+## The Observe suite
 
-TokenJam is also a full observability stack. The seven analyzers and Lens ride on top.
+The loop applies fixes on workspace agents and advises plus verifies everywhere else. Around it,
+TokenJam is also a full, local-first observability stack for every agent you run.
 
 - **Real-time cost tracking**: every LLM call priced as it happens
 - **Safety alerts**: 13 alert types, 6 channels (ntfy, Discord, Telegram, webhook, file, stdout)
 - **Behavioral drift detection**: Z-score baselines, no LLM required
 - **Schema validation**: declare or infer JSON Schema for tool outputs
-- **Context & quota audits**: `tj context` (re-read vs. net-new split) and `tj quota-audit` (retroactive Opus usage check) over your Claude Code sessions
-- **Close the loop**: `tj loop` annotates a run with a verdict, promotes a bad run into a stored expectation, and tracks whether later runs pass or regress against it
-- **Prompt summarization (advisory)**: `tj summarize` finds prompt files worth condensing and estimates the per-call saving
-- **Enforcement-plane proxy (suggest mode)**: `tj proxy` surfaces routing suggestions locally, without rewriting requests
+- **Context & premium-model audits**: `tj context` (re-read vs. net-new split) and `tj quota-audit`
+  (retroactive Opus-usage check) over your Claude Code sessions
+- **Close the loop**: `tj loop` annotates a run with a verdict, promotes a bad run into a stored
+  expectation, and tracks whether later runs pass or regress against it
+- **Prompt summarization (advisory)**: `tj summarize` finds prompt files worth condensing and
+  estimates the per-call saving
+- **Enforcement-plane proxy (suggest mode)**: `tj proxy` surfaces routing suggestions locally,
+  without rewriting requests
 - **OTel-native**: point any OTLP exporter at `tj serve` and you're done
-- **Statusline**: a zero-token Claude Code status line (`tj statusline`, wired by `tj onboard --claude-code`) showing this session's re-read share + a `/compact` nudge
-- **MCP server**: in-request-path tools for **SDK / API** users (not Claude Code / Codex subscription users, since an in-loop MCP would be a per-turn quota burden there; they get the out-of-band statusline instead)
+- **Statusline**: a zero-token Claude Code status line (`tj statusline`, wired by
+  `tj onboard --claude-code`) showing this session's re-read share + a `/compact` nudge
+- **MCP server**: in-request-path tools for **SDK / API** users (not Claude Code / Codex subscription
+  users, since an in-loop MCP would be a per-turn burden there; they get the out-of-band statusline
+  instead)
 
 ---
 
@@ -258,9 +331,10 @@ Bench reports measured pass-rate on a suite, never "certified" or "quality prese
 
 ## Roadmap
 
-**Shipped:** Downsize · Cache · Script · Trim · Reuse · Subagent right-sizing · Claude Code + Codex onboarding · MCP server · Lens web UI · Backfill adapters (Langfuse, Helicone, OTLP) · Period comparison · Routing-config export · Read-only policy preview · Context & quota audits · Close-the-loop annotations/expectations · Prompt summarization (advisory) · Enforcement-plane proxy (suggest mode)
+**Shipped:** Self-improve loop (detect, propose, approve, apply, verify) on workspace agents, plus detect, advise, and verify for any OTel agent · Downsize · Cache · Script · Trim · Reuse · Subagent right-sizing · Claude Code + Codex onboarding · MCP server · Lens web UI (Improve + Observe lenses) · Backfill adapters (Langfuse, Helicone, OTLP) · Period comparison · Routing-config export · Read-only policy preview · Context & premium-model audits · Close-the-loop annotations/expectations · Prompt summarization (advisory) · Enforcement-plane proxy (suggest mode)
 
 **Up next** (roughly):
+- [ ] Auto-apply for Agent SDK app repos, on the same human-gated ladder
 - [ ] Continued Lens polish + per-product visual branding
 - [ ] `tj policy add | edit | apply`: unified rule surface (today: `tj policy list` / `tj policy decisions`)
 - [ ] `tj replay`: replay captured sessions against new model versions
@@ -286,7 +360,7 @@ TokenJam is MIT, and contributions are welcome: from a one-line pricing fix to a
 
 Setup and the full dev workflow are in **[CONTRIBUTING.md](CONTRIBUTING.md)**.
 
-If TokenJam saves you tokens, **star it** and **watch for releases**; we ship often.
+If TokenJam stops your agents repeating mistakes, **star it** and **watch for releases**; we ship often.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ it checks whether the mistake actually stopped.
 npx tokenjam        # a read-only report of your agent's recurring mistakes. nothing installed, nothing kept
 ```
 
-Bare `npx tokenjam` reads the Claude Code logs you already have and prints the potholes your agent
-keeps driving into. When you want the loop that fixes them, onboard:
+Bare `npx tokenjam` reads the Claude Code logs you already have and prints the recurring mistakes your
+agent keeps repeating. When you want the loop that fixes them, onboard:
 
 ```bash
 npx tokenjam onboard   # or: pipx install tokenjam && tj onboard
@@ -61,8 +61,8 @@ Five stages, human-gated where it counts.
    and OTel spans for everything else, then clusters the blockers your agent silently re-hits across
    sessions: wrong-directory reads, edit-before-read, blocked sleep loops, stale-read races,
    domain-blocked fetches. A pattern has to recur across at least three distinct sessions before it
-   becomes a **pothole**.
-2. **Propose.** For each pothole TokenJam drafts the lightest fix that could work, on a ladder:
+   counts as a recurring mistake worth fixing.
+2. **Propose.** For each recurring mistake TokenJam drafts the lightest fix that could work, on a ladder:
    a **note** appended to your `CLAUDE.md`, then a **skill** (`.claude/skills/<name>/SKILL.md`), then
    a runtime **hook** (or wrapper / config) that catches the mistake as it happens.
 3. **Approve.** Nothing is written until you say so. You review the evidence (the repro sessions) and
@@ -78,7 +78,7 @@ Five stages, human-gated where it counts.
 
 You drive this from three places, no new command to learn: `tj onboard` surfaces your first fix, the
 `tj serve` daemon keeps the detector warm and serves the **Review inbox** in Lens (where you approve,
-apply, and watch verification), and `tj optimize pothole` prints the current potholes from the CLI.
+apply, and watch verification), and `tj optimize relearn` prints the current findings from the CLI.
 
 ---
 
@@ -227,7 +227,7 @@ Per-subagent cost breakdown; flags premium-model or over-contexted `Task` calls 
 </tr>
 </table>
 
-`tj optimize` (no args) runs every analyzer: the six above, plus `pothole` (the self-improve loop's
+`tj optimize` (no args) runs every analyzer: the six above, plus `relearn` (the self-improve loop's
 detector), `verbosity` (sessions whose output runs high versus the per-task-shape median),
 `budget-projection` (projects your monthly run-rate against a configured `[budget.<provider>]`
 ceiling), and `cache-recommend` (the Cache card's breakpoint-suggestion half). Run a subset with

--- a/README.md
+++ b/README.md
@@ -229,8 +229,9 @@ Per-subagent cost breakdown; flags premium-model or over-contexted `Task` calls 
 
 `tj optimize` (no args) runs every analyzer: the six above, plus `relearn` (the self-improve loop's
 detector), `verbosity` (sessions whose output runs high versus the per-task-shape median),
-`budget-projection` (projects your monthly run-rate against a configured `[budget.<provider>]`
-ceiling), and `cache-recommend` (the Cache card's breakpoint-suggestion half). Run a subset with
+`summarize` (structure-aware prompt-file summarization candidates), `budget-projection` (projects your
+monthly run-rate against a configured `[budget.<provider>]` ceiling), and `cache-recommend` (the Cache
+card's breakpoint-suggestion half). Run a subset with
 `tj optimize downsize cache reuse`.
 
 ---

--- a/npm-wrapper/README.md
+++ b/npm-wrapper/README.md
@@ -20,7 +20,7 @@ npx tokenjam onboard   # set up the loop that fixes them, or: pipx install token
 
 ## What you get
 
-`tj onboard` is guided setup: it writes a config, generates an ingest secret, and asks how you use AI agents (Claude Code, Codex, or your own SDK/API agents) to wire the right path. For Claude Code and Codex that means backfilling recent history and installing a statusline and hooks for live capture; restart and you're live. Onboarding ends by showing the mistakes your agent keeps making and offers to enable your first fix, and it unlocks the self-improve loop, all six analyzers, the Lens dashboard, and the zero-token statusline in one command.
+`tj onboard` is guided setup: it writes a config, generates an ingest secret, and asks how you use AI agents (Claude Code, Codex, or your own SDK/API agents) to wire the right path. For Claude Code and Codex that means backfilling recent history and installing a statusline and hooks for live capture; restart and you're live. Onboarding ends by showing the mistakes your agent keeps making and offers to enable your first fix, and it unlocks the loop, all six analyzers, the Lens dashboard, and the zero-token statusline in one command.
 
 ## Commands
 
@@ -29,7 +29,7 @@ All arguments pass straight through to the Python CLI, so any `tj` subcommand an
 | Command | What it does |
 |---|---|
 | `npx tokenjam` | Zero-install report of the recurring mistakes your agent keeps repeating. Nothing installed, nothing kept. |
-| `npx tokenjam onboard` | Guided setup for the self-improve loop: writes a config, generates an ingest secret, and optionally installs the background daemon for live capture. |
+| `npx tokenjam onboard` | Guided setup for the loop: writes a config, generates an ingest secret, and optionally installs the background daemon for live capture. |
 | `npx tokenjam context` | Where your tokens go: re-read vs. net-new share, recurring inclusions, `/compact` candidates. |
 | `npx tokenjam optimize` | Savings candidates: model downsizing, cache opportunities, prompt trimming, workflow reuse, subagent right-sizing. |
 
@@ -42,7 +42,7 @@ tj optimize   # cost-saving candidates from your actual usage
 tj serve      # open the Lens dashboard at http://127.0.0.1:7391/
 ```
 
-- Full feature set, the self-improve loop, six analyzers, and Lens screenshots: [github.com/Metabuilder-Labs/tokenjam](https://github.com/Metabuilder-Labs/tokenjam)
+- Full feature set, the loop, six analyzers, and Lens screenshots: [github.com/Metabuilder-Labs/tokenjam](https://github.com/Metabuilder-Labs/tokenjam)
 - Product site and docs: [tokenjam.dev](https://tokenjam.dev)
 
 ## How the launcher works

--- a/npm-wrapper/README.md
+++ b/npm-wrapper/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-<img src="https://raw.githubusercontent.com/Metabuilder-Labs/tokenjam/main/docs/brand/tokenjam-repo-header.png" alt="TokenJam: token efficiency for AI agents. Reads your agent's telemetry, finds the waste, runs 100% local." width="760">
+<img src="https://raw.githubusercontent.com/Metabuilder-Labs/tokenjam/main/docs/brand/tokenjam-repo-header.png" alt="TokenJam cuts what your AI agents cost by ending the mistakes they keep repeating: it finds the failures your agent re-hits, fixes them, and verifies the waste stopped. Runs 100% local." width="760">
 
 [![npm](https://img.shields.io/npm/v/tokenjam?color=3d8eff&labelColor=0d1117)](https://www.npmjs.com/package/tokenjam)
 [![npm downloads](https://img.shields.io/npm/dm/tokenjam?color=3d8eff&labelColor=0d1117&label=downloads)](https://www.npmjs.com/package/tokenjam)
@@ -11,15 +11,16 @@
 
 </div>
 
-TokenJam ingests telemetry data about your agents from a multitude of sources and provides you a quick and easy way to visualize and optimize cost so that you get the most out of the tokens you pay for. This package is the zero-install launcher: no pip environment, no manual config.
+TokenJam cuts what your AI agents cost by ending their repeated mistakes: it finds the failures your agent keeps re-hitting, fixes them at the harness level, and verifies the waste stopped. It ingests agent telemetry from a multitude of sources (Claude Code sessions, Claude Agent SDK apps, any OTel source) into a local DuckDB, so you get the most out of the tokens you pay for. This package is the zero-install launcher: no pip environment, no manual config.
 
 ```bash
-npx tokenjam onboard   # or: pipx install tokenjam && tj onboard
+npx tokenjam        # a read-only report of your agent's recurring mistakes, no install, nothing kept
+npx tokenjam onboard   # set up the loop that fixes them, or: pipx install tokenjam && tj onboard
 ```
 
 ## What you get
 
-`tj onboard` is guided setup: it writes a config, generates an ingest secret, and asks how you use AI agents (Claude Code, Codex, or your own SDK/API agents) to wire the right path. For Claude Code and Codex that means backfilling recent history and installing a statusline and hooks for live capture; restart and you're live. Onboarding unlocks all six analyzers, the Lens dashboard, and the zero-token statusline in one command.
+`tj onboard` is guided setup: it writes a config, generates an ingest secret, and asks how you use AI agents (Claude Code, Codex, or your own SDK/API agents) to wire the right path. For Claude Code and Codex that means backfilling recent history and installing a statusline and hooks for live capture; restart and you're live. Onboarding ends by showing the mistakes your agent keeps making and offers to enable your first fix, and it unlocks the self-improve loop, all seven analyzers, the Lens dashboard, and the zero-token statusline in one command.
 
 ## Commands
 
@@ -27,10 +28,10 @@ All arguments pass straight through to the Python CLI, so any `tj` subcommand an
 
 | Command | What it does |
 |---|---|
-| `npx tokenjam onboard` | Guided setup: writes a config, generates an ingest secret, and optionally installs the background daemon for live capture. |
-| `npx tokenjam context` | Where your quota goes: re-read vs. net-new share, recurring inclusions, `/compact` candidates. |
-| `npx tokenjam optimize` | Cost-saving candidates: model downsizing, cache opportunities, prompt trimming, workflow reuse, subagent right-sizing. |
-| `npx tokenjam` | Bare run: still works, still zero-install, still a reference passthrough to the Python CLI. |
+| `npx tokenjam` | Zero-install report of the recurring mistakes your agent keeps repeating. Nothing installed, nothing kept. |
+| `npx tokenjam onboard` | Guided setup for the self-improve loop: writes a config, generates an ingest secret, and optionally installs the background daemon for live capture. |
+| `npx tokenjam context` | Where your tokens go: re-read vs. net-new share, recurring inclusions, `/compact` candidates. |
+| `npx tokenjam optimize` | Savings candidates: model downsizing, cache opportunities, prompt trimming, workflow reuse, subagent right-sizing. |
 
 ## Go deeper
 
@@ -41,7 +42,7 @@ tj optimize   # cost-saving candidates from your actual usage
 tj serve      # open the Lens dashboard at http://127.0.0.1:7391/
 ```
 
-- Full feature set, six analyzers, and Lens screenshots: [github.com/Metabuilder-Labs/tokenjam](https://github.com/Metabuilder-Labs/tokenjam)
+- Full feature set, the self-improve loop, seven analyzers, and Lens screenshots: [github.com/Metabuilder-Labs/tokenjam](https://github.com/Metabuilder-Labs/tokenjam)
 - Product site and docs: [tokenjam.dev](https://tokenjam.dev)
 
 ## How the launcher works

--- a/npm-wrapper/README.md
+++ b/npm-wrapper/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-<img src="https://raw.githubusercontent.com/Metabuilder-Labs/tokenjam/main/docs/brand/tokenjam-repo-header.png" alt="TokenJam cuts what your AI agents cost by ending the mistakes they keep repeating: it finds the failures your agent re-hits, fixes them, and verifies the waste stopped. Runs 100% local." width="760">
+<img src="https://raw.githubusercontent.com/Metabuilder-Labs/tokenjam/main/docs/brand/tokenjam-repo-header.png" alt="TokenJam: the self-improvement loop for AI agents. Finds the mistakes your agent keeps repeating, fixes them, and proves they stopped. Runs 100% local." width="760">
 
 [![npm](https://img.shields.io/npm/v/tokenjam?color=3d8eff&labelColor=0d1117)](https://www.npmjs.com/package/tokenjam)
 [![npm downloads](https://img.shields.io/npm/dm/tokenjam?color=3d8eff&labelColor=0d1117&label=downloads)](https://www.npmjs.com/package/tokenjam)
@@ -11,7 +11,7 @@
 
 </div>
 
-TokenJam cuts what your AI agents cost by ending their repeated mistakes: it finds the failures your agent keeps re-hitting, fixes them at the harness level, and verifies the waste stopped. It ingests agent telemetry from a multitude of sources (Claude Code sessions, Claude Agent SDK apps, any OTel source) into a local DuckDB, so you get the most out of the tokens you pay for. This package is the zero-install launcher: no pip environment, no manual config.
+TokenJam is the self-improvement loop for AI agents: it finds the mistakes your agent keeps repeating, fixes them, and proves they stopped. It ingests agent telemetry from many sources (Claude Code sessions, any OTel source) into a local DuckDB. This package is the zero-install launcher: no pip environment, no manual config.
 
 ```bash
 npx tokenjam        # a read-only report of your agent's recurring mistakes, no install, nothing kept

--- a/npm-wrapper/README.md
+++ b/npm-wrapper/README.md
@@ -20,7 +20,7 @@ npx tokenjam onboard   # set up the loop that fixes them, or: pipx install token
 
 ## What you get
 
-`tj onboard` is guided setup: it writes a config, generates an ingest secret, and asks how you use AI agents (Claude Code, Codex, or your own SDK/API agents) to wire the right path. For Claude Code and Codex that means backfilling recent history and installing a statusline and hooks for live capture; restart and you're live. Onboarding ends by showing the mistakes your agent keeps making and offers to enable your first fix, and it unlocks the self-improve loop, all seven analyzers, the Lens dashboard, and the zero-token statusline in one command.
+`tj onboard` is guided setup: it writes a config, generates an ingest secret, and asks how you use AI agents (Claude Code, Codex, or your own SDK/API agents) to wire the right path. For Claude Code and Codex that means backfilling recent history and installing a statusline and hooks for live capture; restart and you're live. Onboarding ends by showing the mistakes your agent keeps making and offers to enable your first fix, and it unlocks the self-improve loop, all six analyzers, the Lens dashboard, and the zero-token statusline in one command.
 
 ## Commands
 
@@ -42,7 +42,7 @@ tj optimize   # cost-saving candidates from your actual usage
 tj serve      # open the Lens dashboard at http://127.0.0.1:7391/
 ```
 
-- Full feature set, the self-improve loop, seven analyzers, and Lens screenshots: [github.com/Metabuilder-Labs/tokenjam](https://github.com/Metabuilder-Labs/tokenjam)
+- Full feature set, the self-improve loop, six analyzers, and Lens screenshots: [github.com/Metabuilder-Labs/tokenjam](https://github.com/Metabuilder-Labs/tokenjam)
 - Product site and docs: [tokenjam.dev](https://tokenjam.dev)
 
 ## How the launcher works

--- a/npm-wrapper/README.md
+++ b/npm-wrapper/README.md
@@ -20,7 +20,7 @@ npx tokenjam onboard   # set up the loop that fixes them, or: pipx install token
 
 ## What you get
 
-`tj onboard` is guided setup: it writes a config, generates an ingest secret, and asks how you use AI agents (Claude Code, Codex, or your own SDK/API agents) to wire the right path. For Claude Code and Codex that means backfilling recent history and installing a statusline and hooks for live capture; restart and you're live. Onboarding ends by showing the mistakes your agent keeps making and offers to enable your first fix, and it unlocks the loop, all six analyzers, the Lens dashboard, and the zero-token statusline in one command.
+`tj onboard` is guided setup: it writes a config, generates an ingest secret, and asks how you use AI agents (Claude Code, Codex, or your own SDK/API agents) to wire the right path. For Claude Code and Codex that means backfilling recent history and installing a statusline and hooks for live capture; restart and you're live. Onboarding ends by showing the mistakes your agent keeps making and offers to enable your first fix, and it unlocks the loop, all twelve analyzers, the Lens dashboard, and the zero-token statusline in one command.
 
 ## Commands
 
@@ -42,7 +42,7 @@ tj optimize   # cost-saving candidates from your actual usage
 tj serve      # open the Lens dashboard at http://127.0.0.1:7391/
 ```
 
-- Full feature set, the loop, six analyzers, and Lens screenshots: [github.com/Metabuilder-Labs/tokenjam](https://github.com/Metabuilder-Labs/tokenjam)
+- Full feature set, the loop, twelve analyzers, and Lens screenshots: [github.com/Metabuilder-Labs/tokenjam](https://github.com/Metabuilder-Labs/tokenjam)
 - Product site and docs: [tokenjam.dev](https://tokenjam.dev)
 
 ## How the launcher works

--- a/npm-wrapper/README.md
+++ b/npm-wrapper/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-<img src="https://raw.githubusercontent.com/Metabuilder-Labs/tokenjam/main/docs/brand/tokenjam-repo-header.png" alt="TokenJam: the self-improvement loop for AI agents. Finds the mistakes your agent keeps repeating, fixes them, and proves they stopped. Runs 100% local." width="760">
+<img src="https://raw.githubusercontent.com/Metabuilder-Labs/tokenjam/main/docs/brand/tokenjam-repo-header.png" alt="TokenJam cuts what your AI agents cost by ending the mistakes they keep repeating: it finds the failures your agent re-hits, fixes them, and verifies the waste stopped. Runs 100% local." width="760">
 
 [![npm](https://img.shields.io/npm/v/tokenjam?color=3d8eff&labelColor=0d1117)](https://www.npmjs.com/package/tokenjam)
 [![npm downloads](https://img.shields.io/npm/dm/tokenjam?color=3d8eff&labelColor=0d1117&label=downloads)](https://www.npmjs.com/package/tokenjam)
@@ -11,7 +11,7 @@
 
 </div>
 
-TokenJam is the self-improvement loop for AI agents: it finds the mistakes your agent keeps repeating, fixes them, and proves they stopped. It ingests agent telemetry from many sources (Claude Code sessions, any OTel source) into a local DuckDB. This package is the zero-install launcher: no pip environment, no manual config.
+TokenJam cuts what your AI agents cost by ending their repeated mistakes: it finds the failures your agent keeps re-hitting, fixes them at the harness level, and verifies the waste stopped. It ingests agent telemetry from a multitude of sources (Claude Code sessions, Claude Agent SDK apps, any OTel source) into a local DuckDB, so you get the most out of the tokens you pay for. This package is the zero-install launcher: no pip environment, no manual config.
 
 ```bash
 npx tokenjam        # a read-only report of your agent's recurring mistakes, no install, nothing kept

--- a/npm-wrapper/README.md
+++ b/npm-wrapper/README.md
@@ -20,7 +20,7 @@ npx tokenjam onboard   # set up the loop that fixes them, or: pipx install token
 
 ## What you get
 
-`tj onboard` is guided setup: it writes a config, generates an ingest secret, and asks how you use AI agents (Claude Code, Codex, or your own SDK/API agents) to wire the right path. For Claude Code and Codex that means backfilling recent history and installing a statusline and hooks for live capture; restart and you're live. Onboarding ends by showing the mistakes your agent keeps making and offers to enable your first fix, and it unlocks the loop, all twelve analyzers, the Lens dashboard, and the zero-token statusline in one command.
+`tj onboard` is guided setup: it writes a config, generates an ingest secret, and asks how you use AI agents (Claude Code, Codex, or your own SDK/API agents) to wire the right path. For Claude Code and Codex that means backfilling recent history and installing a statusline and hooks for live capture; restart and you're live. Onboarding ends by showing the mistakes your agent keeps making and offers to enable your first fix, and it unlocks the loop, all thirteen analyzers, the Lens dashboard, and the zero-token statusline in one command.
 
 ## Commands
 
@@ -42,7 +42,7 @@ tj optimize   # cost-saving candidates from your actual usage
 tj serve      # open the Lens dashboard at http://127.0.0.1:7391/
 ```
 
-- Full feature set, the loop, twelve analyzers, and Lens screenshots: [github.com/Metabuilder-Labs/tokenjam](https://github.com/Metabuilder-Labs/tokenjam)
+- Full feature set, the loop, thirteen analyzers, and Lens screenshots: [github.com/Metabuilder-Labs/tokenjam](https://github.com/Metabuilder-Labs/tokenjam)
 - Product site and docs: [tokenjam.dev](https://tokenjam.dev)
 
 ## How the launcher works

--- a/npm-wrapper/README.md
+++ b/npm-wrapper/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-<img src="https://raw.githubusercontent.com/Metabuilder-Labs/tokenjam/main/docs/brand/tokenjam-repo-header.png" alt="TokenJam cuts what your AI agents cost by ending the mistakes they keep repeating: it finds the failures your agent re-hits, fixes them, and verifies the waste stopped. Runs 100% local." width="760">
+<img src="https://raw.githubusercontent.com/Metabuilder-Labs/tokenjam/main/docs/brand/tokenjam-repo-header.png" alt="TokenJam cuts what your AI agents cost by ending the mistakes they keep repeating: it finds the failures your agent re-hits and fixes them, reversibly and human-gated. Runs 100% local." width="760">
 
 [![npm](https://img.shields.io/npm/v/tokenjam?color=3d8eff&labelColor=0d1117)](https://www.npmjs.com/package/tokenjam)
 [![npm downloads](https://img.shields.io/npm/dm/tokenjam?color=3d8eff&labelColor=0d1117&label=downloads)](https://www.npmjs.com/package/tokenjam)
@@ -11,11 +11,11 @@
 
 </div>
 
-TokenJam cuts what your AI agents cost by ending their repeated mistakes: it finds the failures your agent keeps re-hitting, fixes them at the harness level, and verifies the waste stopped. It ingests agent telemetry from a multitude of sources (Claude Code sessions, Claude Agent SDK apps, any OTel source) into a local DuckDB, so you get the most out of the tokens you pay for. This package is the zero-install launcher: no pip environment, no manual config.
+TokenJam cuts what your AI agents cost by ending their repeated mistakes: it finds the failures your agent keeps re-hitting and fixes them at the harness level, reversibly and human-gated. It ingests agent telemetry from a multitude of sources (Claude Code sessions, Claude Agent SDK apps, any OTel source) into a local DuckDB, so you get the most out of the tokens you pay for. This package is the zero-install launcher: no pip environment, no manual config.
 
 ```bash
-npx tokenjam        # a read-only report of your agent's recurring mistakes, no install, nothing kept
-npx tokenjam onboard   # set up the loop that fixes them, or: pipx install tokenjam && tj onboard
+npx tokenjam        # a read-only report of where your Claude Code quota goes, no install, nothing kept
+npx tokenjam onboard   # set up the loop that finds and fixes recurring mistakes, or: pipx install tokenjam && tj onboard
 ```
 
 ## What you get
@@ -28,7 +28,7 @@ All arguments pass straight through to the Python CLI, so any `tj` subcommand an
 
 | Command | What it does |
 |---|---|
-| `npx tokenjam` | Zero-install report of the recurring mistakes your agent keeps repeating. Nothing installed, nothing kept. |
+| `npx tokenjam` | Zero-install report of where your Claude Code quota goes: re-reads vs. net-new work, plus a session timeline. Nothing installed, nothing kept. |
 | `npx tokenjam onboard` | Guided setup for the loop: writes a config, generates an ingest secret, and optionally installs the background daemon for live capture. |
 | `npx tokenjam context` | Where your tokens go: re-read vs. net-new share, recurring inclusions, `/compact` candidates. |
 | `npx tokenjam optimize` | Savings candidates: model downsizing, cache opportunities, prompt trimming, workflow reuse, subagent right-sizing. |

--- a/tests/unit/test_docs_analyzer_count.py
+++ b/tests/unit/test_docs_analyzer_count.py
@@ -1,0 +1,94 @@
+"""The analyzer count claimed in user-facing docs must match the registry.
+
+This number has drifted every time an analyzer landed: the docs said six while
+the registry held twelve, and the four places that stated it did not even agree
+with each other. A reader cannot check a count, so a stale one is simply a
+false claim. Derive it from ``ANALYZER_REGISTRY`` instead of trusting prose.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+import tokenjam.core.optimize.analyzers  # noqa: F401  (populates the registry)
+from tokenjam.core.optimize.registry import ANALYZER_REGISTRY
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+#: Every doc that states how many analyzers ship. Historical release-test
+#: records under tests/results/ are excluded on purpose: they record what a
+#: past run observed and must not be rewritten.
+DOCS = (
+    "README.md",
+    "CLAUDE.md",
+    "npm-wrapper/README.md",
+    "docs/first-hour.md",
+    "docs/agent-capability-matrix.md",
+    "docs/cli-reference.md",
+)
+
+_NUMBER_WORDS = {
+    "one": 1, "two": 2, "three": 3, "four": 4, "five": 5, "six": 6,
+    "seven": 7, "eight": 8, "nine": 9, "ten": 10, "eleven": 11, "twelve": 12,
+    "thirteen": 13, "fourteen": 14, "fifteen": 15, "sixteen": 16,
+    "seventeen": 17, "eighteen": 18, "nineteen": 19, "twenty": 20,
+}
+
+_ANALYZERS_RE = re.compile(r"\banalyzers?\b", re.IGNORECASE)
+_WORD_RE = re.compile(r"[\w-]+")
+
+#: How many words before "analyzers" a count may sit: "twelve analyzers",
+#: "twelve cost-optimization analyzers", "all twelve registry-driven analyzers".
+_LOOKBACK_WORDS = 3
+
+#: The reversed table-header form: "Analyzers (twelve: downsize / ...)".
+_TRAILING_COUNT_RE = re.compile(r"\banalyzers? \(([a-z]+)[:,]", re.IGNORECASE)
+
+
+def _as_count(token: str) -> int | None:
+    """The number a token spells, or None. Spelled-out words only: a bare
+    integer near the word "analyzer" is nearly always a line number, a version
+    or a percentage, and every claim site here spells the count out."""
+    return _NUMBER_WORDS.get(token.lower())
+
+
+def _claimed_counts(text: str) -> list[int]:
+    """Every "<n> analyzers" claim in `text`, as integers.
+
+    Scans backwards from each occurrence of the word rather than matching a
+    single regex forwards: "all six analyzers" and "the twelve
+    cost-optimization analyzers" put the number a different distance away, and
+    a forward pattern with an optional middle greedily swallows the number.
+    """
+    counts = []
+    for match in _ANALYZERS_RE.finditer(text):
+        preceding = _WORD_RE.findall(text[:match.start()])[-_LOOKBACK_WORDS:]
+        for token in reversed(preceding):
+            count = _as_count(token)
+            if count is not None:
+                counts.append(count)
+                break
+    for raw in _TRAILING_COUNT_RE.findall(text):
+        count = _as_count(raw)
+        if count is not None:
+            counts.append(count)
+    return counts
+
+
+@pytest.mark.parametrize("relpath", DOCS)
+def test_doc_analyzer_count_matches_the_registry(relpath):
+    expected = len(ANALYZER_REGISTRY)
+    text = (REPO_ROOT / relpath).read_text(encoding="utf-8")
+    wrong = [n for n in _claimed_counts(text) if n != expected]
+    assert not wrong, (
+        f"{relpath} claims {wrong} analyzer(s); the registry holds {expected}: "
+        f"{sorted(ANALYZER_REGISTRY)}"
+    )
+
+
+def test_the_registry_is_the_number_the_docs_were_updated_to():
+    """A tripwire on the number itself. Adding or removing an analyzer should
+    fail here first, as the prompt to go update every doc listed above."""
+    assert len(ANALYZER_REGISTRY) == 13


### PR DESCRIPTION
> **Stack slice of #482.** Sits on top of the internal-docs PR #521, so the diff shows only the public copy.
>
> This is the last PR in the chain, which is deliberate: it carries `tests/unit/test_docs_analyzer_count.py`, a guard asserting every doc states the same analyzer count as the code registry. That test can only pass once all the code and all the docs are present, so it lives here.

Public-facing copy only.

- `README.md` and `npm-wrapper/README.md` repositioned to lead with cost and to name the mechanism plainly. The install headline stays npx-first; entry copy is no longer Claude-Code-only.
- `tests/unit/test_docs_analyzer_count.py`: the doc/registry consistency guard (verified passing on this branch).
