### PR TITLE
chore: pin mypy in dev extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,15 @@ litellm   = ["litellm>=1.40"]
 # on main. Bump this deliberately (and fix or explicitly re-suppress
 # whatever the new default set newly flags) rather than letting a ruff
 # release silently redefine what "lint-clean" means for every PR.
-dev       = ["pytest", "pytest-asyncio", "httpx", "ruff>=0.15.12,<0.16", "mypy"]
+# mypy>=2.3,<2.4: same rationale as the ruff pin above — an unpinned `mypy`
+# here means CI's `pip install -e ".[dev,mcp]"` picks up whatever release is
+# newest at job run time, and a new mypy version can start flagging
+# pre-existing code the same way ruff 0.16.0 did. Pinned to the 2.3.x line,
+# which `mypy tokenjam/` runs clean against as of this pin (2.3.0 verified
+# clean, 217 source files, zero errors). Bump this deliberately (and fix or
+# explicitly re-suppress whatever a new release newly flags) rather than
+# letting a mypy release silently redefine what "type-clean" means for every PR.
+dev       = ["pytest", "pytest-asyncio", "httpx", "ruff>=0.15.12,<0.16", "mypy>=2.3,<2.4"]
 # Kept as a no-op extra for back-compat — `pipx install 'tokenjam[mcp]'` still
 # works, just installs the same fastmcp that's now in the base dependencies.
 # Documented in `docs/installation.md` so users know they no longer need it.


### PR DESCRIPTION
## Summary

The ruff pin in the dev extra was already narrowed to a compatible range in a prior PR, with a comment explaining why (an unpinned lint tool lets CI silently pick up a new release's default rule changes on unrelated PRs). `mypy` in that same extra was left completely unpinned, with the identical failure mode: a new mypy release can start flagging pre-existing code on any PR, unrelated to that PR's diff.

This PR pins `mypy` the same way, mirroring the existing ruff pin's style and comment tone.

## Changes

- `pyproject.toml`: `mypy` in the `dev` extra pinned to `>=2.3,<2.4`, with a comment explaining the rationale (matching the ruff comment above it).
- No changes to the ruff pin, its comment, or any lint configuration.

## Verification

- `mypy --version` → `mypy 2.3.0` (the pinned range resolves to the newest available release)
- `mypy tokenjam/` → `Success: no issues found in 217 source files`
- `ruff check tokenjam/` → `All checks passed!` (confirms untouched)
- `pytest tests/unit/` → `2886 passed, 2 skipped`

## Test plan

- [x] `mypy tokenjam/` clean under the pinned version
- [x] `ruff check tokenjam/` still clean, pin unchanged
- [x] `pytest tests/unit/` full suite green