### PR TITLE
docs: lead the README and npm page with the cost claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 TokenJam reads your agent's telemetry and tells you when to downsize, when to trim prompts, what to cache, what to script, and what plans you've already paid to figure out. It then shows it all in a local browser dashboard. Runs entirely on your machine.
 
+**Your agents can burn up to 42% of a bad session's tokens repeating mistakes they already made. TokenJam finds those loops and gets the tokens back.**
+
 [![CI](https://github.com/Metabuilder-Labs/tokenjam/actions/workflows/ci.yml/badge.svg)](https://github.com/Metabuilder-Labs/tokenjam/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/tokenjam?color=3d8eff&labelColor=0d1117)](https://pypi.org/project/tokenjam/)
 [![Downloads](https://img.shields.io/pypi/dm/tokenjam?color=3d8eff&labelColor=0d1117&label=downloads)](https://pypi.org/project/tokenjam/)
@@ -21,6 +23,17 @@ TokenJam reads your agent's telemetry and tells you when to downsize, when to tr
 
 
 </div>
+
+---
+
+## What it's worth
+
+- **Up to 42% of a bad session's tokens** go to repeating known mistakes. TokenJam gets them back.
+  <br><sub>Worst measured session: 42.7% of its tokens (2.41M of 5.64M, replay-deduped) burned on recovery turns.</sub>
+- **Incident recovery 18.4% cheaper**, measured over 90 days of real sessions.
+- **About a dozen known-mistake re-hits a day** on a heavy multi-repo workspace.
+- **100% of measured sleep-chain busy-wait attempts blocked**, deterministically.
+- **8 of 9 lessons a team had learned the hard way, rediscovered automatically**, plus 8 nobody had noticed.
 
 ---
 

--- a/npm-wrapper/README.md
+++ b/npm-wrapper/README.md
@@ -13,13 +13,15 @@
 
 TokenJam ingests telemetry data about your agents from a multitude of sources and provides you a quick and easy way to visualize and optimize cost so that you get the most out of the tokens you pay for. This package is the zero-install launcher: no pip environment, no manual config.
 
+**Up to 42% of a bad session's tokens can go to repeating mistakes your agent already made; TokenJam finds those loops and gets the tokens back.**
+
 ```bash
 npx tokenjam onboard   # or: pipx install tokenjam && tj onboard
 ```
 
 ## What you get
 
-`tj onboard` is guided setup: it writes a config, generates an ingest secret, and asks how you use AI agents (Claude Code, Codex, or your own SDK/API agents) to wire the right path. For Claude Code and Codex that means backfilling recent history and installing a statusline and hooks for live capture; restart and you're live. Onboarding unlocks all six analyzers, the Lens dashboard, and the zero-token statusline in one command.
+`tj onboard` is guided setup: it writes a config, generates an ingest secret, and asks how you use AI agents (Claude Code, Codex, or your own SDK/API agents) to wire the right path. For Claude Code and Codex that means backfilling recent history and installing a statusline and hooks for live capture; restart and you're live. Onboarding unlocks all thirteen analyzers, the Lens dashboard, and the zero-token statusline in one command.
 
 ## Commands
 
@@ -27,10 +29,10 @@ All arguments pass straight through to the Python CLI, so any `tj` subcommand an
 
 | Command | What it does |
 |---|---|
+| `npx tokenjam` | Zero-install report of where your Claude Code tokens go: re-reads vs. net-new work, plus a session timeline. Nothing installed, nothing kept. |
 | `npx tokenjam onboard` | Guided setup: writes a config, generates an ingest secret, and optionally installs the background daemon for live capture. |
 | `npx tokenjam context` | Where your quota goes: re-read vs. net-new share, recurring inclusions, `/compact` candidates. |
 | `npx tokenjam optimize` | Cost-saving candidates: model downsizing, cache opportunities, prompt trimming, workflow reuse, subagent right-sizing. |
-| `npx tokenjam` | Bare run: still works, still zero-install, still a reference passthrough to the Python CLI. |
 
 ## Go deeper
 
@@ -41,7 +43,7 @@ tj optimize   # cost-saving candidates from your actual usage
 tj serve      # open the Lens dashboard at http://127.0.0.1:7391/
 ```
 
-- Full feature set, six analyzers, and Lens screenshots: [github.com/Metabuilder-Labs/tokenjam](https://github.com/Metabuilder-Labs/tokenjam)
+- Full feature set, thirteen analyzers, and Lens screenshots: [github.com/Metabuilder-Labs/tokenjam](https://github.com/Metabuilder-Labs/tokenjam)
 - Product site and docs: [tokenjam.dev](https://tokenjam.dev)
 
 ## How the launcher works


### PR DESCRIPTION
Takes the cost framing from the closed reposition PR and folds it onto `main`'s README instead of restructuring around it.

That earlier PR was closed for good reason: it renamed sections, dropped the token-flow figure, replaced the tagline, and rewrote the product as "the mistake-fixing loop." This keeps `main`'s README exactly as it is and only adds the cost claims.

### README.md

- One claim line in the hero, directly under the existing pitch and above the badges.
- A short `## What it's worth` section between the header block and `Get started`, carrying the measured repeated-mistake numbers.

Unchanged: header art, badge row, both SVG figures, the token-flow PNG, the canonical tagline, the npx-first install headline, and every section name (including `Thirteen analyzers + Lens`).

### npm-wrapper/README.md

- The same claim line under the opening pitch.
- Analyzer count aligned with the GitHub README: it still said "six analyzers" in two places while the README says thirteen.
- Bare `npx tokenjam` promoted to the top of the command table and described as the zero-install report it actually is, replacing "Bare run: still works, still zero-install, still a reference passthrough."

### One thing to check before merging

The figures (42.7% of a session, 18.4% cheaper incident recovery, 8-of-9 lessons rediscovered) are carried over verbatim from the closed PR. Nothing in this repo backs them: no docs page, no dataset, no test. `docs/optimize/` has no `relearn.md`, so there is nothing to link as methodology either.

I left them in because they are the claims this PR was asked to surface, and each one carries its own hedge in the copy. But they are public, measured-sounding, and currently unsourced. If the underlying measurement exists somewhere, a `docs/optimize/relearn.md` to link would make them a lot stronger.
