### PR TITLE
relearn: stop inventing root causes for text-less failures, and four defects around it

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -102,6 +102,13 @@ scan_min_rescan_seconds = 60     # floor between rescans that actually re-run
                                  #   the analyzers; 0 disables the limit
 scan_ui_poll_seconds    = 300    # how often an open page asks for a rescan;
                                  #   0 turns the browser's auto-rescan off
+scan_watermark_min_new_spans        = 1   # a scheduled tick (never an explicit
+                                 #   rescan) skips the pass unless at least
+                                 #   this many new spans landed since the last
+                                 #   one; 0 always runs
+scan_watermark_max_staleness_hours  = 24.0 # a scheduled tick always runs once
+                                 #   this long has passed since the last pass,
+                                 #   even with zero new spans
 ```
 
 Overlapping scans never stack: a rescan pressed while one is already running is

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -3255,6 +3255,37 @@ async def test_get_session_distill_reports_candidate_count(
 
 
 @pytest.mark.asyncio
+async def test_get_session_distill_threads_scoped_cache_dir(
+    config, db, tmp_path, monkeypatch
+):
+    """The route's distill calls must be scoped to the active config's
+    storage dir, never the unscoped ~/.tj default (`core.distill._default_
+    cache_dir`) — a served API route writing into the operator's real home
+    regardless of --projects-root/--db scope was a live leak."""
+    seen: dict = {}
+
+    def _capture(*_a, **k):
+        seen["cache_dir"] = k.get("cache_dir")
+        return {}
+
+    monkeypatch.setattr(
+        "tokenjam.api.routes.sessions.distill_titles_cached", _capture)
+    _write_story_transcript(tmp_path, "scope-sess")
+    pipeline = IngestPipeline(db=db, config=config)
+    app = create_app(config=config, db=db, ingest_pipeline=pipeline)
+    app.state.claude_projects_root = tmp_path
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        resp = await c.get("/api/v1/sessions/scope-sess/distill")
+    assert resp.status_code == 200
+
+    from tokenjam.core.distill import _default_cache_dir
+
+    assert seen["cache_dir"] == _default_cache_dir(config)
+
+
+@pytest.mark.asyncio
 async def test_get_session_distill_unavailable(config, db, tmp_path):
     # No transcript on disk -> available:false with HTTP 200 (no CLI call).
     pipeline = IngestPipeline(db=db, config=config)

--- a/tests/unit/test_backfill.py
+++ b/tests/unit/test_backfill.py
@@ -117,6 +117,52 @@ def test_parse_returns_none_for_file_with_no_assistant_turns(tmp_path):
     assert parse_claude_code_session(path) is None
 
 
+# -- tokenjam's own internal model calls must never be ingested as a session -
+
+def test_parse_excludes_tokenjam_internal_invoke_cwd(tmp_path):
+    """core.distill/core.rulewrite.presence shell out to the SAME `claude`
+    CLI, from a private marker cwd under the system temp root
+    (`core.distill.INVOKE_CWD_DIRNAME`). Their transcripts must never be
+    ingested as a user session — they are tokenjam naming its own findings,
+    not agent work anyone did."""
+    from tokenjam.core.distill import INVOKE_CWD_DIRNAME
+
+    marker_cwd = f"/private/var/folders/xx/yyyy/T/{INVOKE_CWD_DIRNAME}"
+    path = _make_session_file(
+        tmp_path,
+        session_id="sess-internal",
+        cwd=marker_cwd,
+        records=[
+            _assistant_record(
+                "msg-1", "claude-haiku-4-5", 100, 20,
+                "2026-04-01T10:00:00.000Z", "sess-internal", marker_cwd,
+            ),
+        ],
+    )
+    assert parse_claude_code_session(path) is None
+
+
+def test_parse_keeps_a_real_session_genuinely_working_out_of_tmp(tmp_path):
+    """A user's own project can legitimately live under /tmp — only
+    tokenjam's OWN marker subdirectory is excluded, never the bare temp root
+    or an unrelated subdirectory of it."""
+    real_tmp_cwd = "/tmp/my-scratch-project"
+    path = _make_session_file(
+        tmp_path,
+        session_id="sess-real-tmp",
+        cwd=real_tmp_cwd,
+        records=[
+            _assistant_record(
+                "msg-1", "claude-opus-4-7", 1000, 200,
+                "2026-04-01T10:00:00.000Z", "sess-real-tmp", real_tmp_cwd,
+            ),
+        ],
+    )
+    parsed = parse_claude_code_session(path)
+    assert parsed is not None
+    assert parsed.session_id == "sess-real-tmp"
+
+
 def test_iter_walks_root(tmp_path):
     _make_session_file(
         tmp_path,

--- a/tests/unit/test_distill.py
+++ b/tests/unit/test_distill.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import json
 import subprocess
+import tempfile
+from pathlib import Path
 
 from tokenjam.core import distill
 
@@ -97,7 +99,9 @@ def test_distill_invocation_uses_pinned_recipe(monkeypatch):
     assert "did a thing in detail" in kwargs["input"]
     assert kwargs["capture_output"] is True
     assert kwargs["text"] is True
-    assert kwargs["cwd"]  # neutral temp dir, non-empty
+    # Neutral AND positively identifiable — see INVOKE_CWD_DIRNAME.
+    assert kwargs["cwd"]
+    assert distill.is_tokenjam_invoke_cwd(kwargs["cwd"])
 
 
 def test_distill_parses_unfenced_result(monkeypatch):
@@ -340,6 +344,33 @@ def test_default_cache_dir_with_config_never_resolves_to_real_home(monkeypatch, 
 
     assert not str(cache_dir).startswith(str(fake_home))
     assert (fake_home / ".tj").exists() is False
+
+
+def test_invoke_cwd_marker_is_positively_identified():
+    marker_cwd = f"/private/var/folders/xx/yyyy/T/{distill.INVOKE_CWD_DIRNAME}"
+    assert distill.is_tokenjam_invoke_cwd(marker_cwd) is True
+
+
+def test_a_real_users_bare_tmp_cwd_is_not_flagged():
+    """The whole point of the dedicated marker directory, not a bare
+    'under the temp root' match: a user genuinely working out of /tmp must
+    never be excluded."""
+    assert distill.is_tokenjam_invoke_cwd("/tmp") is False
+    assert distill.is_tokenjam_invoke_cwd("/tmp/my-project") is False
+    assert distill.is_tokenjam_invoke_cwd(None) is False
+    assert distill.is_tokenjam_invoke_cwd("") is False
+
+
+def test_invoke_cwd_resolves_under_the_temp_root(monkeypatch, tmp_path):
+    """`_invoke_cwd` (what `_invoke_claude` actually passes as `cwd=`) always
+    resolves to a directory whose basename `is_tokenjam_invoke_cwd` accepts —
+    the two halves of this fix must agree with each other."""
+    monkeypatch.setattr(tempfile, "gettempdir", lambda: str(tmp_path))
+
+    resolved = distill._invoke_cwd()
+
+    assert distill.is_tokenjam_invoke_cwd(resolved) is True
+    assert Path(resolved).is_dir()
 
 
 def test_default_cache_dir_without_config_keeps_legacy_home_path(monkeypatch, tmp_path):

--- a/tests/unit/test_distill.py
+++ b/tests/unit/test_distill.py
@@ -319,3 +319,37 @@ def test_cache_corrupt_file_treated_as_miss(monkeypatch, tmp_path):
     assert result == {1: "fresh"}
     cached = json.loads((tmp_path / "sess-1.json").read_text())
     assert cached["titles"] == {"1": "fresh"}
+
+
+# -- Cache-path scoping (--projects-root / --db must never leak to ~/.tj) ----
+#
+# Mirrors test_relearn_apply.py::test_memory_storage_path_never_resolves_to_real_home:
+# a fake, obviously-not-real HOME lets the test prove the resolved cache dir
+# is NOT under it. `_default_cache_dir` used to take no config at all and
+# always resolved to the real ~/.tj/distill_cache regardless of scope.
+
+def test_default_cache_dir_with_config_never_resolves_to_real_home(monkeypatch, tmp_path):
+    from tokenjam.core.config import StorageConfig, TjConfig
+
+    fake_home = tmp_path / "definitely-not-the-real-home"
+    fake_home.mkdir()
+    monkeypatch.setattr(distill.Path, "home", classmethod(lambda cls: fake_home))
+
+    cfg = TjConfig(version="1", storage=StorageConfig(path=":memory:"))
+    cache_dir = distill._default_cache_dir(cfg)
+
+    assert not str(cache_dir).startswith(str(fake_home))
+    assert (fake_home / ".tj").exists() is False
+
+
+def test_default_cache_dir_without_config_keeps_legacy_home_path(monkeypatch, tmp_path):
+    """No config -> the historical hardcoded ~/.tj/distill_cache, unchanged —
+    every existing caller that never had a config to thread stays on today's
+    behaviour."""
+    fake_home = tmp_path / "some-home"
+    fake_home.mkdir()
+    monkeypatch.setattr(distill.Path, "home", classmethod(lambda cls: fake_home))
+
+    cache_dir = distill._default_cache_dir()
+
+    assert cache_dir == fake_home / ".tj" / "distill_cache"

--- a/tests/unit/test_relearn.py
+++ b/tests/unit/test_relearn.py
@@ -703,7 +703,7 @@ def test_name_fallback_evidence_is_too_thin_even_when_the_text_looks_substantive
     assert _evidence_too_thin_for_distill(cluster) is True
 
 
-def test_name_fallback_cluster_is_never_distilled():
+def test_name_fallback_cluster_is_never_distilled(tmp_path):
     """Same treatment as any other confidence-gate suppression (see
     `test_confidence_gate_suppresses_confabulations_even_with_a_warm_cache`):
     a cluster the gate rejects is dropped, not distilled and not passed
@@ -725,7 +725,7 @@ def test_name_fallback_cluster_is_never_distilled():
         ],
     )
 
-    result = apply_distill_to_residual([cluster], enabled=True)
+    result = apply_distill_to_residual([cluster], cache_dir=tmp_path / "distill_cache", enabled=True)
 
     assert result == []
 

--- a/tests/unit/test_relearn.py
+++ b/tests/unit/test_relearn.py
@@ -674,6 +674,62 @@ def test_legit_evidence_is_not_too_thin(family, samples):
     assert _evidence_too_thin_for_distill(cluster) is False
 
 
+def test_name_fallback_evidence_is_too_thin_even_when_the_text_looks_substantive():
+    """A name-fallback failure's error_text is the span's own NAME (e.g.
+    ``gen_ai.tool.call``), which reads as ordinary words rather than noise —
+    ``_is_substantive_error_text`` alone would wave it through. The explicit
+    ``error_text_is_name_fallback`` check must reject it regardless, since
+    there is no diagnosis in it for distill to ground a fix in. This
+    exercises the SECOND, independent gate directly: `_failure_signature`
+    already keeps a real span-sourced cluster like this from ever recurring
+    (see test_relearn_otel.py), so this test bypasses that by building the
+    `_RawCluster` by hand, as if it had somehow reached this function."""
+    from tokenjam.core.optimize.analyzers.relearn import (
+        FailureEpisode,
+        _RawCluster,
+        _evidence_too_thin_for_distill,
+    )
+
+    cluster = _RawCluster(
+        signature="Bash:__no_error_text__", family_key=None, title="Bash: no error text captured",
+        failures=[
+            FailureEpisode(
+                f"s{i}", "repo", None, "Bash", "", "gen_ai.tool.call", "act", False, 0,
+                error_text_is_name_fallback=True,
+            )
+            for i in range(3)
+        ],
+    )
+    assert _evidence_too_thin_for_distill(cluster) is True
+
+
+def test_name_fallback_cluster_is_never_distilled():
+    """Same treatment as any other confidence-gate suppression (see
+    `test_confidence_gate_suppresses_confabulations_even_with_a_warm_cache`):
+    a cluster the gate rejects is dropped, not distilled and not passed
+    through with a fabricated title."""
+    from tokenjam.core.optimize.analyzers.relearn import (
+        FailureEpisode,
+        _RawCluster,
+        apply_distill_to_residual,
+    )
+
+    cluster = _RawCluster(
+        signature="Bash:__no_error_text__", family_key=None, title="Bash: no error text captured",
+        failures=[
+            FailureEpisode(
+                f"s{i}", "repo", None, "Bash", "", "gen_ai.tool.call", "act", False, 0,
+                error_text_is_name_fallback=True,
+            )
+            for i in range(3)
+        ],
+    )
+
+    result = apply_distill_to_residual([cluster], enabled=True)
+
+    assert result == []
+
+
 def test_confidence_gate_suppresses_confabulations_even_with_a_warm_cache(tmp_path):
     """The gate runs BEFORE the cache is ever consulted — even a stale cache
     entry from before this fix (holding the exact real confabulated answer)

--- a/tests/unit/test_relearn_otel.py
+++ b/tests/unit/test_relearn_otel.py
@@ -15,6 +15,7 @@ from datetime import datetime, timedelta, timezone
 import pytest
 
 from tokenjam.core.db import InMemoryBackend
+from tokenjam.core import distill as distill_mod
 from tokenjam.core.optimize.analyzers.relearn import (
     FailureEpisode,
     analyze_relearns,
@@ -88,6 +89,13 @@ def test_skips_coding_agents_so_transcripts_are_not_double_counted(db):
 
 
 def test_falls_back_to_span_name_when_no_status_message(db):
+    """A span with no ``status_message`` still becomes a FailureEpisode (the
+    failure is real, and the money it cost is real — see
+    BELOW_THRESHOLD_BASIS), but the fallback text is the span's own NAME, not
+    a diagnosis. It must be marked as such: `error_text_is_name_fallback`
+    downstream keeps it out of the distill pass and out of any shared
+    signature with unrelated failures (see `_failure_signature` /
+    `_evidence_too_thin_for_distill` in `analyzers/relearn.py`)."""
     span = make_tool_span(
         agent_id="billing-svc", tool_name="", status="error",
         session_id="s1", start_time=BASE, name="gen_ai.tool.call",
@@ -99,6 +107,17 @@ def test_falls_back_to_span_name_when_no_status_message(db):
 
     assert len(failures) == 1
     assert failures[0].error_text == "gen_ai.tool.call"
+    assert failures[0].error_text_is_name_fallback is True
+
+
+def test_real_status_message_is_not_flagged_as_name_fallback(db):
+    _seed_failure(db, agent_id="billing-svc", session_id="s1",
+                  message="ConnectionResetError: peer closed")
+
+    failures = extract_span_failures(db.conn)
+
+    assert len(failures) == 1
+    assert failures[0].error_text_is_name_fallback is False
 
 
 def test_since_filters_older_spans(db):
@@ -153,6 +172,83 @@ def test_recurring_span_failures_become_a_proposal(db):
     assert finding.clusters[0].sessions == 3
     # Span-sourced sessions count as scanned exposure.
     assert finding.sessions_scanned == 3
+
+
+def test_text_less_span_failures_never_merge_across_sessions(db):
+    """Old behavior: every span with no status_message on the same tool fell
+    back to the SAME span-name string and clustered as one shared signature
+    across every session, however unrelated the underlying calls actually
+    were. Now a name-fallback failure is scoped to its own session — see
+    `_failure_signature` in analyzers/relearn.py."""
+    for i, sid in enumerate(("s1", "s2", "s3", "s4")):
+        span = make_tool_span(
+            agent_id="billing-svc", tool_name="Bash", status="error",
+            session_id=sid, start_time=BASE + timedelta(minutes=i),
+            name="gen_ai.tool.call",
+        )
+        span.status_message = None
+        db.insert_span(span)
+
+    failures = extract_span_failures(db.conn)
+    assert len(failures) == 4
+    assert all(f.error_text_is_name_fallback for f in failures)
+
+    clusters = cluster_failures(failures)
+
+    # Four unrelated no-error-text failures must never collapse into one
+    # shared signature — each keeps its own, one per session.
+    assert len(clusters) == 4
+    assert all(len(c.session_ids) == 1 for c in clusters.values())
+
+
+def test_text_less_span_failures_never_become_a_recurring_proposal(db):
+    for i, sid in enumerate(("s1", "s2", "s3", "s4", "s5")):
+        span = make_tool_span(
+            agent_id="billing-svc", tool_name="Bash", status="error",
+            session_id=sid, start_time=BASE + timedelta(minutes=i),
+            name="gen_ai.tool.call",
+        )
+        span.status_message = None
+        db.insert_span(span)
+
+    finding = analyze_relearns(
+        [], extra_failures=extract_span_failures(db.conn),
+        advise_only_repos=non_coding_agent_ids(db.conn), distill_enabled=False,
+    )
+
+    # Never a recurring cluster despite 5 sessions all hitting the same
+    # name-fallback shape — the cost is still counted, as below-threshold
+    # residue (Critical Rule 32(b): the money stays counted), just never
+    # asserted as a named, recurring relearn.
+    assert finding.clusters == []
+    assert finding.below_threshold_occurrences == 5
+
+
+def test_text_less_spans_never_reach_the_distill_pass(db, monkeypatch):
+    """The primary fix: spending a model call to NAME a failure that carries
+    no error text at all must never happen, however many sessions hit it."""
+    def _boom(*_args, **_kwargs):
+        raise AssertionError("distill must never be invoked for a name-fallback cluster")
+
+    monkeypatch.setattr(distill_mod, "_invoke_claude", _boom)
+
+    for i, sid in enumerate(("s1", "s2", "s3", "s4", "s5")):
+        span = make_tool_span(
+            agent_id="billing-svc", tool_name="Bash", status="error",
+            session_id=sid, start_time=BASE + timedelta(minutes=i),
+            name="gen_ai.tool.call",
+        )
+        span.status_message = None
+        db.insert_span(span)
+
+    # distill_enabled=True on purpose — this proves the exclusion, not the
+    # opt-out flag.
+    finding = analyze_relearns(
+        [], extra_failures=extract_span_failures(db.conn),
+        advise_only_repos=non_coding_agent_ids(db.conn), distill_enabled=True,
+    )
+
+    assert finding.clusters == []
 
 
 def test_below_recurrence_threshold_does_not_surface(db):

--- a/tests/unit/test_scan_cycle_provenance.py
+++ b/tests/unit/test_scan_cycle_provenance.py
@@ -444,3 +444,61 @@ def test_the_shared_cache_does_not_drop_the_cost_builds_stamp(cfg):
     # The keys this whitelist already carried, pinned in the same place so the
     # next addition is caught by the same test rather than by a live daemon.
     assert after["cost_window_days"] == 30
+
+
+def test_an_unnamed_cost_key_survives_the_relearn_leg(cfg):
+    """`write_cache` and `read_cost_proposals` copy `cost_*` keys through by
+    PREFIX now, not by a hand-written list — so a key neither of them has ever
+    heard of must still round-trip. Deliberately does not name any key that
+    appears in `relearn_store`'s source: naming one here would let the guard
+    pass by accident if the prefix rule ever regressed back into a whitelist
+    that happened to still include that one name.
+    """
+    from dataclasses import dataclass, field
+
+    from tokenjam.core.optimize import relearn_store
+
+    relearn_store.write_cost_proposals([], config=cfg, window_days=30)
+    p = relearn_store.default_cache_path(cfg)
+    raw = json.loads(p.read_text(encoding="utf-8"))
+    raw["cost_zzz_never_named_anywhere_in_source"] = "sentinel"
+    p.write_text(json.dumps(raw), encoding="utf-8")
+
+    @dataclass
+    class _Finding:
+        clusters: list = field(default_factory=list)
+
+    relearn_store.write_cache(_Finding(), config=cfg)
+    after = relearn_store.read_cost_proposals(config=cfg) or {}
+    assert after.get("cost_zzz_never_named_anywhere_in_source") == "sentinel", (
+        "the relearn write dropped a cost_* key it does not itself name"
+    )
+
+
+def test_a_recorded_cost_error_survives_the_relearn_leg(cfg):
+    """A cost-proposals recompute failure is state, not noise: it flags the
+    Review inbox as degraded until a later recompute clears it. The relearn
+    leg shares the same cache file and used to rebuild it from a whitelist
+    that never named `cost_proposals_error`/`cost_proposals_error_at`, so the
+    very next relearn recompute silently erased a recorded failure and the
+    surface read as if nothing had gone wrong.
+    """
+    from dataclasses import dataclass, field
+
+    from tokenjam.core.optimize import relearn_store
+
+    relearn_store.write_cost_proposals([], config=cfg, window_days=30)
+    relearn_store.write_cost_proposals_error("boom: recompute failed", config=cfg)
+    before = relearn_store.read_cost_proposals(config=cfg) or {}
+    assert before["cost_proposals_error"] == "boom: recompute failed"
+
+    @dataclass
+    class _Finding:
+        clusters: list = field(default_factory=list)
+
+    relearn_store.write_cache(_Finding(), config=cfg)
+    after = relearn_store.read_cost_proposals(config=cfg) or {}
+    assert after["cost_proposals_error"] == "boom: recompute failed", (
+        "the relearn write dropped a recorded cost-proposals error"
+    )
+    assert after["cost_proposals_error_at"] == before["cost_proposals_error_at"]

--- a/tests/unit/test_scan_watermark.py
+++ b/tests/unit/test_scan_watermark.py
@@ -1,0 +1,206 @@
+"""The ingestion-watermark gate on the SCHEDULED analyzer-pass trigger.
+
+THE DEFECT THIS GUARDS AGAINST. The daemon's scan-cycle job used to be a pure
+wall-clock ``interval`` — it re-ran the full analyzer pass, including the
+relearn distill pass's LLM subprocess calls, every ``scan_interval_hours``
+regardless of whether any new telemetry had landed. On an idle machine that
+recomputes an answer that cannot have changed.
+
+Four properties:
+
+1. An idle tick (no new spans since the last pass) is a no-op.
+2. A tick after enough new spans have landed DOES trigger.
+3. The staleness ceiling forces a pass on a quiet machine even with zero new
+   spans, so a machine that never sees traffic still refreshes eventually.
+4. An explicit rescan (``force=True``) always attempts a pass, bypassing the
+   gate entirely — a human asking is never deferred to the next tick.
+"""
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+
+from tokenjam.core.config import OptimizeConfig, StorageConfig, TjConfig
+from tokenjam.core.optimize import ingest_watermark, report_store, scan_cycle
+from tokenjam.utils.time_parse import utcnow
+
+
+@pytest.fixture(autouse=True)
+def _reset_watermark_state():
+    """Both halves are MODULE-GLOBAL — a leaked value from one test would
+    silently gate (or un-gate) every later test in the process, in any file.
+    Cleared on both sides, same pattern as `_CYCLE_COMPUTING` in
+    `test_scan_cycle_provenance.py`."""
+    scan_cycle._CYCLE_COMPUTING.clear()
+    scan_cycle._last_pass_watermark = None
+    scan_cycle._last_pass_at = None
+    ingest_watermark._count = 0
+    yield
+    scan_cycle._CYCLE_COMPUTING.clear()
+    scan_cycle._last_pass_watermark = None
+    scan_cycle._last_pass_at = None
+    ingest_watermark._count = 0
+
+
+@pytest.fixture
+def cfg(tmp_path) -> TjConfig:
+    return TjConfig(
+        version="1",
+        storage=StorageConfig(path=str(tmp_path / "t.duckdb")),
+        optimize=OptimizeConfig(
+            scan_watermark_min_new_spans=5,
+            scan_watermark_max_staleness_hours=12.0,
+        ),
+    )
+
+
+def _fake_thread_capturing(sink: list):
+    def _fake_thread(target=None, name=None, daemon=None):
+        class _T:
+            def start(_self):
+                sink.append(target)
+        return _T()
+    return _fake_thread
+
+
+# --------------------------------------------------------------------------- #
+# 0. Nothing has run yet in this process -> the gate must not block the first
+#    tick (the startup kick relies on exactly this).
+# --------------------------------------------------------------------------- #
+def test_first_tick_in_a_fresh_process_always_runs(cfg):
+    assert scan_cycle._should_run_scheduled_pass(cfg) is True
+
+
+# --------------------------------------------------------------------------- #
+# 1. Idle tick: no new spans since the last completed pass -> no-op
+# --------------------------------------------------------------------------- #
+def test_idle_tick_with_no_new_spans_does_not_trigger(monkeypatch, cfg):
+    scan_cycle._record_pass_watermark(ingest_watermark.current())
+
+    dispatched: list = []
+    monkeypatch.setattr(scan_cycle.threading, "Thread", _fake_thread_capturing(dispatched))
+    monkeypatch.setattr(report_store, "is_computing", lambda: False)
+
+    started = scan_cycle.trigger_scan_cycle(lambda: None, cfg)
+
+    assert started == {"analyzer_pass": False}
+    assert not dispatched, "an idle tick must never dispatch the pass thread"
+
+
+# --------------------------------------------------------------------------- #
+# 2. A tick after enough new spans DOES trigger
+# --------------------------------------------------------------------------- #
+def test_tick_after_enough_new_sessions_triggers(monkeypatch, cfg):
+    scan_cycle._record_pass_watermark(ingest_watermark.current())
+    ingest_watermark.bump(cfg.optimize.scan_watermark_min_new_spans)
+
+    dispatched: list = []
+    monkeypatch.setattr(scan_cycle.threading, "Thread", _fake_thread_capturing(dispatched))
+    monkeypatch.setattr(report_store, "is_computing", lambda: False)
+
+    started = scan_cycle.trigger_scan_cycle(lambda: None, cfg)
+
+    assert started == {"analyzer_pass": True}
+    assert dispatched, "enough new spans must dispatch the pass thread"
+
+
+def test_a_trickle_below_the_threshold_does_not_trigger(monkeypatch, cfg):
+    scan_cycle._record_pass_watermark(ingest_watermark.current())
+    ingest_watermark.bump(cfg.optimize.scan_watermark_min_new_spans - 1)
+
+    dispatched: list = []
+    monkeypatch.setattr(scan_cycle.threading, "Thread", _fake_thread_capturing(dispatched))
+    monkeypatch.setattr(report_store, "is_computing", lambda: False)
+
+    started = scan_cycle.trigger_scan_cycle(lambda: None, cfg)
+
+    assert started == {"analyzer_pass": False}
+    assert not dispatched
+
+
+# --------------------------------------------------------------------------- #
+# 3. The staleness ceiling forces a pass on a quiet machine
+# --------------------------------------------------------------------------- #
+def test_the_ceiling_forces_a_pass_on_a_quiet_machine(monkeypatch, cfg):
+    # No new spans at all — only the elapsed time crosses the ceiling.
+    scan_cycle._record_pass_watermark(ingest_watermark.current())
+    scan_cycle._last_pass_at = utcnow() - timedelta(
+        hours=cfg.optimize.scan_watermark_max_staleness_hours + 1,
+    )
+
+    dispatched: list = []
+    monkeypatch.setattr(scan_cycle.threading, "Thread", _fake_thread_capturing(dispatched))
+    monkeypatch.setattr(report_store, "is_computing", lambda: False)
+
+    started = scan_cycle.trigger_scan_cycle(lambda: None, cfg)
+
+    assert started == {"analyzer_pass": True}
+    assert dispatched, "a stale-enough machine must refresh even with zero new spans"
+
+
+def test_within_the_ceiling_and_below_threshold_stays_quiet(cfg):
+    scan_cycle._record_pass_watermark(ingest_watermark.current())
+    scan_cycle._last_pass_at = utcnow() - timedelta(
+        hours=cfg.optimize.scan_watermark_max_staleness_hours - 1,
+    )
+    assert scan_cycle._should_run_scheduled_pass(cfg) is False
+
+
+# --------------------------------------------------------------------------- #
+# 4. An explicit user rescan always runs, watermark or not
+# --------------------------------------------------------------------------- #
+def test_explicit_rescan_always_runs_regardless_of_the_watermark(monkeypatch, cfg):
+    # Set up the exact state that gates a scheduled tick...
+    scan_cycle._record_pass_watermark(ingest_watermark.current())
+
+    dispatched: list = []
+    monkeypatch.setattr(scan_cycle.threading, "Thread", _fake_thread_capturing(dispatched))
+    monkeypatch.setattr(report_store, "is_computing", lambda: False)
+
+    # ...and confirm the SAME state would have declined a scheduled tick.
+    assert scan_cycle._should_run_scheduled_pass(cfg) is False
+
+    started = scan_cycle.trigger_scan_cycle(lambda: None, cfg, force=True)
+
+    assert started == {"analyzer_pass": True}
+    assert dispatched, "force=True must never be deferred by the watermark gate"
+
+
+# --------------------------------------------------------------------------- #
+# 5. A completed pass advances the watermark baseline
+# --------------------------------------------------------------------------- #
+def test_a_completed_pass_advances_the_watermark_baseline(monkeypatch, cfg):
+    ingest_watermark.bump(cfg.optimize.scan_watermark_min_new_spans)
+
+    monkeypatch.setattr(report_store, "is_computing", lambda: False)
+    monkeypatch.setattr(
+        report_store, "recompute_now",
+        lambda backend, config, until=None: {"computed_at": "now"},
+    )
+    monkeypatch.setattr(report_store, "stored_report", lambda config: object())
+    monkeypatch.setattr(scan_cycle, "_write_relearn_from", lambda *a, **k: None)
+
+    import tokenjam.core.optimize.cost_proposals as cp
+    monkeypatch.setattr(
+        cp, "recompute_cost_proposals",
+        lambda backend, config, until=None, report=None: None,
+    )
+    monkeypatch.setattr(scan_cycle, "_refresh_rule_presence", lambda config: None)
+
+    threads: list = []
+    monkeypatch.setattr(scan_cycle.threading, "Thread", _fake_thread_capturing(threads))
+
+    started = scan_cycle.trigger_scan_cycle(lambda: None, cfg)
+    assert started == {"analyzer_pass": True}
+    threads[0]()  # run the job body inline
+
+    assert scan_cycle._last_pass_watermark == ingest_watermark.current()
+    assert scan_cycle._last_pass_at is not None
+
+    # A second tick right after, with no further ingestion, is now idle again.
+    dispatched: list = []
+    monkeypatch.setattr(scan_cycle.threading, "Thread", _fake_thread_capturing(dispatched))
+    started_again = scan_cycle.trigger_scan_cycle(lambda: None, cfg)
+    assert started_again == {"analyzer_pass": False}
+    assert not dispatched

--- a/tests/unit/test_transcript_sync.py
+++ b/tests/unit/test_transcript_sync.py
@@ -135,6 +135,33 @@ def test_scan_counts_a_file_with_no_session_id_as_unreadable(tmp_path: Path) -> 
     assert sessions == {}
 
 
+def test_scan_excludes_tokenjams_own_internal_invoke_cwd(tmp_path: Path) -> None:
+    """core.distill/core.rulewrite.presence shell out to the same `claude`
+    CLI as any user session, from a private marker cwd
+    (`core.distill.INVOKE_CWD_DIRNAME`). The disk scan that feeds the
+    reconciliation gap report must never surface one of these as a
+    "missing" session — see also core.backfill's exclusion in the parse
+    loop, which this mirrors at the ingest boundary's OTHER read path."""
+    from tokenjam.core.distill import INVOKE_CWD_DIRNAME
+
+    root = tmp_path / "projects"
+    marker_cwd = f"/private/var/folders/xx/yyyy/T/{INVOKE_CWD_DIRNAME}"
+    _write_transcript(
+        root, "-internal", "sess-internal",
+        [_assistant_record("sess-internal", marker_cwd, "u1", "msg1",
+                           _DEFAULT_RECENT_TS)],
+    )
+    # A real session, so the exclusion is proven to be SPECIFIC, not a
+    # blanket "scan found nothing" false negative.
+    _write_session(root, "sess-real")
+
+    sessions, scanned, unreadable = scan_disk_sessions(root)
+
+    assert scanned == 2
+    assert unreadable == 0
+    assert list(sessions) == ["sess-real"]
+
+
 def test_scan_honours_the_since_mtime_prefilter(tmp_path: Path) -> None:
     root = tmp_path / "projects"
     old = _write_session(root, "sess-old")

--- a/tokenjam/api/routes/optimize.py
+++ b/tokenjam/api/routes/optimize.py
@@ -342,7 +342,13 @@ def rescan_optimize(request: Request) -> dict[str, Any]:
     # pressed it from — and the Dashboard's tiles could end up hours fresher
     # than the inbox headline they are naturally compared against. One cycle,
     # one meaning: see `core/optimize/scan_cycle.py`.
-    started = trigger_scan_cycle(lambda: DuckDBBackend(config.storage), config)
+    # force=True: an explicit rescan bypasses the ingestion-watermark gate
+    # (`core/optimize/scan_cycle.py`) — a human asking must always attempt a
+    # pass, never get deferred to the next scheduled tick just because the
+    # corpus hasn't grown.
+    started = trigger_scan_cycle(
+        lambda: DuckDBBackend(config.storage), config, force=True,
+    )
     any_started = any(started.values())
     return {
         **report_store.stored_report_block(config),

--- a/tokenjam/api/routes/sessions.py
+++ b/tokenjam/api/routes/sessions.py
@@ -38,7 +38,7 @@ from fastapi.responses import JSONResponse
 from tokenjam.api.deps import require_api_key
 from tokenjam.api.routes.runs import _child_sessions, _run_sessions
 from tokenjam.core.db import delete_session_label, set_session_label
-from tokenjam.core.distill import distill_titles_cached, peek_cached_titles
+from tokenjam.core.distill import _default_cache_dir, distill_titles_cached, peek_cached_titles
 from tokenjam.core.method_capture import capture_session_method, load_session_method
 from tokenjam.core.framing import (
     WindowSummary,
@@ -1940,10 +1940,15 @@ def get_session_distill(
         if (a.get("outcome") or "").strip()
         and len((a["outcome"]).strip()) >= DISTILL_MIN_OUTCOME_CHARS
     ]
+    # Scoped to the active config, not the historical unscoped ~/.tj default —
+    # an isolated `--projects-root` / `--db` run must never write into the
+    # operator's real home. See `core.distill._default_cache_dir`.
+    config = getattr(request.app.state, "config", None)
+    cache_dir = _default_cache_dir(config)
     if cached_only:
-        titles = peek_cached_titles(session_id, candidates)
+        titles = peek_cached_titles(session_id, candidates, cache_dir=cache_dir)
     else:
-        titles = distill_titles_cached(session_id, candidates)
+        titles = distill_titles_cached(session_id, candidates, cache_dir=cache_dir)
     return {
         "available": True,
         "model": "haiku",

--- a/tokenjam/cli/cmd_serve.py
+++ b/tokenjam/cli/cmd_serve.py
@@ -112,7 +112,13 @@ def cmd_serve(ctx: click.Context, host: str | None, port: int | None,
 
     def _scan_cycle_job() -> None:
         # Resolved through the module (not a from-import) so the scheduled and
-        # startup passes share one patchable seam.
+        # startup passes share one patchable seam. `force` defaults False here
+        # deliberately: this is a SCHEDULED trigger (interval job and the
+        # startup kick both call this same function), so it is subject to the
+        # ingestion-watermark gate in `scan_cycle._should_run_scheduled_pass`
+        # — an idle machine with no new spans since the last pass is a no-op.
+        # The startup kick's own first call still always proceeds: this
+        # process has no prior watermark to compare against yet.
         scan_cycle.trigger_scan_cycle(
             lambda: _DuckDBBackend(config.storage), config,
         )

--- a/tokenjam/core/backfill.py
+++ b/tokenjam/core/backfill.py
@@ -27,6 +27,7 @@ from pathlib import Path
 from typing import Iterator
 
 from tokenjam.core.cost import calculate_cost
+from tokenjam.core.distill import is_tokenjam_invoke_cwd
 from tokenjam.core.pricing import classify_pricing_source
 from tokenjam.core.config import CaptureConfig
 from tokenjam.core.method_capture import capture_session_method
@@ -421,6 +422,14 @@ def parse_claude_code_session(
             session_id = record.get("sessionId")
         if cwd is None:
             cwd = record.get("cwd")
+            # tokenjam's own distill/presence model calls (core.distill,
+            # core.rulewrite.presence) shell out to this SAME `claude` CLI
+            # from a private temp-dir cwd, and leave an ordinary transcript
+            # on disk like any user session — never a session the user
+            # actually worked. Excluded at the earliest possible point (the
+            # first record that reveals cwd) rather than parsed and priced.
+            if cwd is not None and is_tokenjam_invoke_cwd(cwd):
+                return None
 
         rtype = record.get("type")
         if rtype == "user" and capture.prompts and not record.get("isMeta"):

--- a/tokenjam/core/config.py
+++ b/tokenjam/core/config.py
@@ -405,6 +405,18 @@ class OptimizeConfig:
     # How often a UI surface re-reads the stored result (NOT how often the scan
     # runs). Zero disables the UI's auto-refresh entirely.
     scan_ui_poll_seconds: int = 300
+    # Ingestion watermark that gates a SCHEDULED tick (never an explicit
+    # rescan — see `core/optimize/scan_cycle.py`). A tick only re-runs the
+    # expensive analyzer pass when at least this many new spans have landed
+    # since the last pass; below it, the tick is a no-op on an idle machine.
+    # 1 preserves today's "scan on every tick" behaviour for any machine that
+    # saw ANY telemetry; only a genuinely idle tick is skipped.
+    scan_watermark_min_new_spans: int = 1
+    # Ceiling on the above: a scheduled tick re-runs the pass regardless of
+    # the watermark once this many hours have passed since the last one, so a
+    # quiet machine still refreshes eventually rather than never rescanning
+    # again.
+    scan_watermark_max_staleness_hours: float = 24.0
 
 
 @dataclass
@@ -842,6 +854,11 @@ def _parse(raw: dict) -> TjConfig:
             "scan_min_rescan_seconds", OptimizeConfig.scan_min_rescan_seconds)),
         scan_ui_poll_seconds=int(optimize_raw.get(
             "scan_ui_poll_seconds", OptimizeConfig.scan_ui_poll_seconds)),
+        scan_watermark_min_new_spans=int(optimize_raw.get(
+            "scan_watermark_min_new_spans", OptimizeConfig.scan_watermark_min_new_spans)),
+        scan_watermark_max_staleness_hours=float(optimize_raw.get(
+            "scan_watermark_max_staleness_hours",
+            OptimizeConfig.scan_watermark_max_staleness_hours)),
         projects_root=optimize_raw.get("projects_root") or None,
     )
 

--- a/tokenjam/core/db.py
+++ b/tokenjam/core/db.py
@@ -1952,6 +1952,8 @@ class DuckDBBackend:
         # Named-column INSERT so future migrations adding columns don't break
         # positional-arg ordering (migration 4 added billing_account at the
         # end of the table, but we don't want to silently rely on that).
+        from tokenjam.core.optimize import ingest_watermark
+
         with self._write_lock:
             self.conn.execute(
                 "INSERT INTO spans ("
@@ -1983,6 +1985,7 @@ class DuckDBBackend:
                     span.pricing_source, span.sub_agent_type,
                 ],
             )
+        ingest_watermark.bump(1)
 
     def bulk_insert_spans(self, spans: Sequence[NormalizedSpan]) -> None:
         """Columnar bulk-append of many spans in a single vectorized statement.
@@ -2001,6 +2004,8 @@ class DuckDBBackend:
         """
         if not spans:
             return
+        from tokenjam.core.optimize import ingest_watermark
+
         # Write the NDJSON payload OUTSIDE the write lock (pure CPU/IO, no DB),
         # then hold the lock only for the single vectorized INSERT..SELECT.
         fd, path = tempfile.mkstemp(prefix="tj-spans-", suffix=".ndjson")
@@ -2016,6 +2021,12 @@ class DuckDBBackend:
                 os.remove(path)
             except OSError:
                 pass
+        # Upper bound, not the exact post-anti-join insert count: the
+        # anti-join can skip already-present span_ids, and counting precisely
+        # would mean a second query on the hot path for a signal that only
+        # needs "did anything happen". Overcounting only makes the watermark
+        # gate marginally more willing to fire — never less safe.
+        ingest_watermark.bump(len(spans))
 
     def insert_alert(self, alert: Alert) -> None:
         with self._write_lock:

--- a/tokenjam/core/distill.py
+++ b/tokenjam/core/distill.py
@@ -35,6 +35,10 @@ import shutil
 import subprocess
 import tempfile
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tokenjam.core.config import TjConfig
 
 #: Max words a distilled title may contain (instructed to the model).
 MAX_TITLE_WORDS = 6
@@ -249,8 +253,24 @@ def _cache_signature(asks: list[dict], model: str) -> str:
     return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
 
 
-def _default_cache_dir() -> Path:
-    """Default on-disk cache location: ``~/.tj/distill_cache``."""
+def _default_cache_dir(config: TjConfig | None = None) -> Path:
+    """Default on-disk cache location.
+
+    With a ``config`` this honors ``--projects-root`` / ``--db`` scoping the
+    same way ``relearn_store.default_cache_path``,
+    ``report_store.default_report_path`` and
+    ``transcript_cache.default_cache_dir`` already do — routed through
+    ``relearn_apply._storage_base_dir`` (an isolated ``storage.path`` resolves
+    under a scratch root, never the real ``~/.tj``). ``config=None`` (the
+    default) keeps today's hardcoded ``~/.tj/distill_cache`` so a caller with
+    no config to thread — most of this module's own callers — is unchanged.
+    Imported lazily to avoid this pure module picking up an import-time
+    dependency on the rest of the package.
+    """
+    if config is not None:
+        from tokenjam.core.optimize.relearn_apply import _storage_base_dir
+
+        return _storage_base_dir(config) / "distill_cache"
     return Path.home() / ".tj" / "distill_cache"
 
 

--- a/tokenjam/core/distill.py
+++ b/tokenjam/core/distill.py
@@ -34,7 +34,7 @@ import re
 import shutil
 import subprocess
 import tempfile
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -139,6 +139,54 @@ def _extract_titles(result: str, valid_ns: set[int]) -> dict[int, str]:
     return titles
 
 
+#: Sub-directory of the system temp root every ``_invoke_claude`` subprocess
+#: runs from — deliberately NOT the bare temp root. This is tokenjam's own
+#: internal model call (naming a relearn cluster, distilling a title,
+#: checking rule presence), never agent work a user did, but it still writes
+#: an ordinary Claude Code transcript to disk like any other ``claude``
+#: invocation and would otherwise be ingested as one more user session (it
+#: was — see ``core.backfill``/``core.transcript_sync``'s exclusion of this
+#: marker). A bare "cwd resolves under the temp root" check would ALSO catch
+#: a user genuinely working out of ``/tmp``; a dedicated, unlikely-to-collide
+#: directory name lets the ingest boundary positively identify tokenjam's own
+#: calls instead of guessing from a heuristic. See ``is_tokenjam_invoke_cwd``.
+INVOKE_CWD_DIRNAME = "tokenjam-internal-distill-cwd"
+
+
+def _invoke_cwd() -> str:
+    """Resolve (creating if needed) the private subprocess cwd — see
+    ``INVOKE_CWD_DIRNAME``. Falls back to the bare temp root if the
+    subdirectory can't be created (read-only temp, permissions): the call
+    still runs, just without the positive-identification marker, same as
+    before this existed."""
+    marker = Path(tempfile.gettempdir()) / INVOKE_CWD_DIRNAME
+    try:
+        marker.mkdir(parents=True, exist_ok=True)
+        return str(marker)
+    except OSError:
+        return tempfile.gettempdir()
+
+
+def is_tokenjam_invoke_cwd(cwd: str | None) -> bool:
+    """True when a recorded session ``cwd`` is tokenjam's own private
+    subprocess directory (``INVOKE_CWD_DIRNAME``), not a project a user
+    worked in. The ingest boundary (``core.backfill``, ``core.transcript_
+    sync``) uses this to exclude tokenjam's own distill/presence calls from
+    a user's session corpus. Checks the directory's BASENAME only (never a
+    prefix/substring match, and never resolved against the live filesystem —
+    the recorded cwd may no longer exist by ingest time) so it is robust to
+    the temp root itself differing (symlink resolution: macOS records
+    ``/private/var/...`` for a call made against ``/var/...``) — the marker
+    name is unique enough on its own that a basename match is unambiguous.
+    """
+    if not cwd:
+        return False
+    try:
+        return PurePosixPath(cwd.replace("\\", "/")).name == INVOKE_CWD_DIRNAME
+    except (TypeError, ValueError):
+        return False
+
+
 def _invoke_claude(prompt: str, *, model: str, timeout: int) -> str | None:
     """Shell out to the local ``claude`` CLI with ``prompt`` on stdin; return its
     ``result`` string, or ``None`` on any failure (missing CLI, non-zero exit,
@@ -164,15 +212,17 @@ def _invoke_claude(prompt: str, *, model: str, timeout: int) -> str | None:
     ]
 
     try:
-        # Neutral cwd so the CLI loads no project CLAUDE.md / MCP config, keeping
-        # the input tiny and the call cheap.
+        # A private, tokenjam-specific cwd (not the bare temp root) so the
+        # CLI loads no project CLAUDE.md / MCP config, keeping the input tiny
+        # and the call cheap, AND so the transcript this call writes to disk
+        # can be positively excluded at ingest — see INVOKE_CWD_DIRNAME.
         proc = subprocess.run(
             argv,
             input=prompt,
             text=True,
             capture_output=True,
             timeout=timeout,
-            cwd=tempfile.gettempdir(),
+            cwd=_invoke_cwd(),
         )
     except (subprocess.TimeoutExpired, OSError):
         return None

--- a/tokenjam/core/optimize/analyzers/relearn.py
+++ b/tokenjam/core/optimize/analyzers/relearn.py
@@ -607,6 +607,17 @@ class FailureEpisode:
     #: carry no detour and fall back to 1.0 (the conservative floor, and the
     #: value the whole analyzer assumed before this was measured).
     detour_turns: float | None = None
+    #: True when ``error_text`` is NOT the real error — the OTel/archive lanes
+    #: (``core/optimize/relearn_otel.py``) fall back to the span's own NAME
+    #: (e.g. ``gen_ai.tool.call``) when a span carries no ``status_message``.
+    #: That text carries no diagnosis of what actually went wrong, so it must
+    #: never be treated as if it did: it cannot ground an LLM-distilled title
+    #: (there is nothing to distill) and it must not collapse unrelated
+    #: failures into one shared signature just because they all fell back to
+    #: the same generic span name. See ``_failure_signature`` and
+    #: ``_evidence_too_thin_for_distill``. The transcript lane never sets
+    #: this — a transcript's raw tool error is always the real text.
+    error_text_is_name_fallback: bool = False
 
 
 #: Stop looking for the recovery turn after this many steps. Past it the agent
@@ -809,7 +820,22 @@ class _RawCluster:
 def _failure_signature(failure: FailureEpisode) -> tuple[str, str | None, str]:
     """``(signature, family_key, title)`` for one failure: a known family (sig ==
     family_key) or a generic normalized signature. The single classify point
-    ``cluster_failures`` keys on."""
+    ``cluster_failures`` keys on.
+
+    A name-fallback failure (``error_text_is_name_fallback`` — see
+    ``FailureEpisode``) gets a signature scoped to its OWN session rather than
+    the shared generic one every other failure on the same tool would land on.
+    Two genuinely unrelated failures that both happened to carry no error text
+    are not evidence of one root cause, so they must never bucket together —
+    and scoping to the session also guarantees the cluster can never clear the
+    cross-session recurrence gate (``MIN_RECURRING_SESSIONS``), which is what
+    keeps it out of the distill pass without relying on a second check there.
+    The money is still counted: an un-recurring cluster still lands in
+    ``_below_threshold_residue``, never silently dropped.
+    """
+    if failure.error_text_is_name_fallback:
+        sig = f"{failure.tool_name}:__no_error_text__:{failure.session_id}"
+        return sig, None, f"{failure.tool_name}: no error text captured"
     family_key = classify_known_family(failure.tool_name, failure.error_text, failure.label)
     if family_key is not None:
         return family_key, family_key, _FAMILY_BY_KEY[family_key]["title"]
@@ -1019,8 +1045,23 @@ def _evidence_too_thin_for_distill(cluster: _RawCluster, *, sample_cap: int = 8)
     error text — the distill confidence gate. A cluster failing this check is
     suppressed entirely rather than distilled (see ``apply_distill_to_residual``):
     showing a human a confident title + fix that traces to nothing but bare
-    exit codes / leftover stdout is worse than surfacing nothing."""
-    samples = [f.error_text for f in cluster.failures if f.error_text][:sample_cap]
+    exit codes / leftover stdout is worse than surfacing nothing.
+
+    A cluster made entirely of name-fallback failures (``error_text_is_name_fallback``
+    — see ``FailureEpisode``) is rejected outright, never even sampled: that
+    text is the span's own NAME, not a diagnosis, so there is nothing in it
+    for distill to legitimately ground a fix in. In practice
+    ``_failure_signature`` already keeps such a cluster from ever recurring
+    across enough sessions to reach this function at all; this check is the
+    second, independent line of defense so the guarantee does not rest on one
+    mechanism alone.
+    """
+    if cluster.failures and all(f.error_text_is_name_fallback for f in cluster.failures):
+        return True
+    samples = [
+        f.error_text for f in cluster.failures
+        if f.error_text and not f.error_text_is_name_fallback
+    ][:sample_cap]
     if not samples:
         return True
     return not any(_is_substantive_error_text(s) for s in samples)

--- a/tokenjam/core/optimize/analyzers/relearn.py
+++ b/tokenjam/core/optimize/analyzers/relearn.py
@@ -1093,7 +1093,7 @@ def _distill_cached(tool_name: str, cluster: _RawCluster, cache_dir: Path) -> di
 
 
 def apply_distill_to_residual(
-    clusters: list[_RawCluster], *, cache_dir: Path | None = None, enabled: bool = True,
+    clusters: list[_RawCluster], *, cache_dir: Path, enabled: bool = True,
 ) -> list[_RawCluster]:
     """Distill the top (by session count) residual clusters and merge any that
     distill assigns the same ``family_key``. Bounded by ``MAX_DISTILL_CLUSTERS``
@@ -1102,10 +1102,14 @@ def apply_distill_to_residual(
     Clusters already matched to a known family are left untouched. When
     ``enabled`` is False (no ``claude`` CLI / caller opt-out) the residual
     clusters pass through with their generic titles, unmerged.
-    """
-    if cache_dir is None:
-        cache_dir = _distill_cache_dir()
 
+    ``cache_dir`` is REQUIRED and deliberately has no default: the natural
+    default (``_distill_cache_dir()`` with no config) resolves to the real
+    ``~/.tj``, which would write outside an isolated ``--projects-root`` /
+    ``--db`` scope with no signal to the caller. Every real call site
+    resolves it from the active config (``_distill_cache_dir(ctx.config)``)
+    before calling in — pass that scoped path, not the unscoped helper.
+    """
     known = [c for c in clusters if c.family_key is not None]
     residual = [c for c in clusters if c.family_key is None]
     if not enabled or not residual:
@@ -2220,8 +2224,15 @@ def analyze_relearns(
     raw_clusters = cluster_failures(all_failures)
     recurring = _recurring(raw_clusters, min_sessions)
     residue = _below_threshold_residue(raw_clusters, recurring, conn)
+    # apply_distill_to_residual requires an explicit cache_dir (no silent
+    # unscoped default — see its docstring). A caller here with no config to
+    # scope from (standalone helpers, tests) keeps today's historical
+    # ~/.tj-backed path via the config-less resolver; a caller WITH a config
+    # threads it in through `distill_cache_dir` instead, scoped.
     distilled = apply_distill_to_residual(
-        recurring, cache_dir=distill_cache_dir, enabled=distill_enabled,
+        recurring,
+        cache_dir=distill_cache_dir if distill_cache_dir is not None else _distill_cache_dir(),
+        enabled=distill_enabled,
     )
     distilled_count = sum(1 for c in distilled if (c.family_key or "").startswith("distilled:"))
 

--- a/tokenjam/core/optimize/ingest_watermark.py
+++ b/tokenjam/core/optimize/ingest_watermark.py
@@ -1,0 +1,58 @@
+"""A cheap, cannot-lie signal for "has new telemetry landed since X".
+
+THE PROBLEM THIS EXISTS FOR. The daemon's scheduled analyzer pass
+(`scan_cycle.py`) used to be a pure wall-clock `interval` job — it re-ran the
+full analyzer sweep, including the relearn distill pass (full-corpus, several
+LLM subprocess calls), every `scan_interval_hours` regardless of whether a
+single new span had been ingested. On an idle machine that recomputes an
+answer that cannot have changed.
+
+THE SIGNAL. A single process-local counter, bumped at the two DuckDB write
+paths that both the live ingest pipeline and every backfill/catch-up pass
+funnel through (`DuckDBBackend.insert_span`, `.bulk_insert_spans`) — the
+lowest choke point shared by every ingestion source, so nothing needs its own
+bump call. `scan_cycle` reads it once per scheduled tick and compares against
+the value it saw at the start of the last pass it actually ran; a delta below
+`[optimize] scan_watermark_min_new_spans` means the tick is a no-op.
+
+DELIBERATELY IN-MEMORY, NOT PERSISTED. A daemon restart resets it to zero,
+which is fine: `scan_cycle`'s own "never run in this process" state is
+`None` at that point too, so the very next scheduled tick (and the startup
+kick) runs the pass unconditionally rather than trusting a watermark it has
+no history for. The cost of losing the counter across a restart is at most
+one extra pass — a correctness-safe direction to be wrong in, and cheaper
+than a durable counter that could itself be stale, corrupt, or read before a
+migration lands it.
+
+NOT A DEDUPE OR ACCOUNTING SIGNAL. This is a coarse "did anything happen"
+flag, not a count anyone should compute past overspend from — no query, no
+config, no analyzer may ever import this for anything other than the gate
+above.
+"""
+from __future__ import annotations
+
+import threading
+
+_lock = threading.Lock()
+_count = 0
+
+
+def bump(n: int = 1) -> None:
+    """Record that *n* new spans were just written to the store.
+
+    Called from `DuckDBBackend.insert_span` (the live path) and
+    `.bulk_insert_spans` (backfill/catch-up) — the two, and only two, places a
+    span actually lands in DuckDB. `n <= 0` is a no-op so a caller need not
+    special-case an empty batch.
+    """
+    global _count
+    if n <= 0:
+        return
+    with _lock:
+        _count += n
+
+
+def current() -> int:
+    """Monotonically increasing count of spans written since process start."""
+    with _lock:
+        return _count

--- a/tokenjam/core/optimize/relearn_otel.py
+++ b/tokenjam/core/optimize/relearn_otel.py
@@ -148,7 +148,8 @@ def extract_archived_coding_failures(
             continue  # its transcript is still on disk; the transcript lane has it
 
         error_text = (status_message or "").strip()[:MAX_SPAN_ERROR_CHARS]
-        if not error_text:
+        is_name_fallback = not error_text
+        if is_name_fallback:
             error_text = (name or "").strip()
         if not error_text:
             continue
@@ -167,6 +168,7 @@ def extract_archived_coding_failures(
             kind="act",
             is_retry=False,
             depth=0,
+            error_text_is_name_fallback=is_name_fallback,
         ))
     return failures
 
@@ -204,9 +206,13 @@ def extract_span_failures(
 
         # status_message is the real error text. Fall back to the span name so a
         # failure with no message still carries a stable signature; skip only
-        # when neither says anything at all.
+        # when neither says anything at all. The fallback carries no real
+        # diagnosis though — `error_text_is_name_fallback` marks that so
+        # downstream clustering/distill never treat it as if it did (see
+        # `FailureEpisode`).
         error_text = (status_message or "").strip()[:MAX_SPAN_ERROR_CHARS]
-        if not error_text:
+        is_name_fallback = not error_text
+        if is_name_fallback:
             error_text = (name or "").strip()
         if not error_text:
             continue
@@ -225,6 +231,7 @@ def extract_span_failures(
             kind="act",        # no method spine off a span; every failure is an act
             is_retry=False,
             depth=0,
+            error_text_is_name_fallback=is_name_fallback,
         ))
     return failures
 

--- a/tokenjam/core/optimize/relearn_store.py
+++ b/tokenjam/core/optimize/relearn_store.py
@@ -106,33 +106,24 @@ def write_cache(
         "tj_version": tj_build(),
     }
     if "cost_proposals" in existing:
-        payload["cost_proposals"] = existing["cost_proposals"]
-        payload["cost_computed_at"] = existing.get("cost_computed_at")
-        # `cost_window_days`/`cost_excluded` are written alongside
-        # `cost_proposals` by `write_cost_proposals` and read back through
-        # `read_cost_proposals`/`_headline_window_days` (see
-        # `api/routes/relearn.py`) to label the Review inbox headline with the
-        # window its figures were actually observed over. This relearn-detector
-        # write shares the same cache file (see this module's docstring) and
-        # used to preserve only the two keys above, silently forgetting a
-        # non-default cost window on every relearn recompute. Harmless while
-        # every route falls back to the same default, but round-tripping both
-        # keys here means a variable window survives regardless of which
-        # producer wrote the cache last.
-        #
-        # THE WHITELIST IS THE TRAP. Every `cost_*` key a cost write produces has
-        # to be named here or this write silently drops it, and the symptom is
-        # never an error — it is a field that reads as "never stamped". Caught
-        # live: `cost_tj_version` was added to `write_cost_proposals` and omitted
-        # here, so a freshly-booted daemon served a cost payload claiming an
-        # unknown producing build, because the pass writes the cost proposals and
-        # then the relearn cache over the top of them.
-        for key in (
-            "cost_window_days", "cost_since", "cost_until", "cost_excluded",
-            "cost_tj_version",
-        ):
-            if key in existing:
-                payload[key] = existing[key]
+        # THE WHITELIST WAS THE TRAP. This used to copy forward a hand-picked
+        # list of `cost_*` keys, and every new key a cost write introduced had
+        # to be added here or this write silently dropped it — the symptom was
+        # never an error, just a field that read as "never stamped". Caught
+        # live twice: `cost_tj_version` (added to `write_cost_proposals` and
+        # omitted here, so a freshly-booted daemon served a cost payload
+        # claiming an unknown producing build) and `cost_proposals_error`/
+        # `cost_proposals_error_at` (a recorded recompute failure silently
+        # erased by the very next relearn-leg recompute, reading downstream as
+        # if nothing had failed). Copy forward by PREFIX instead: this branch
+        # (unlike `write_cost_proposals_error`/`clear_cost_proposals_error`,
+        # which preserve the WHOLE existing payload) only ever originates
+        # `computed_at`/`finding`/`tj_version` above, so every `cost_`-prefixed
+        # key in `existing` belongs to the cost-proposal producer and none of
+        # them can collide with a key this branch means to set itself.
+        for key, value in existing.items():
+            if key.startswith("cost_"):
+                payload[key] = value
     _atomic_write(p, payload)
     return payload
 
@@ -181,28 +172,29 @@ def read_cost_proposals(
     has_error = "cost_proposals_error" in raw
     if not has_proposals and not has_error:
         return None
-    return {
-        "cost_computed_at": raw.get("cost_computed_at"),
-        "cost_proposals": raw.get("cost_proposals") or [],
-        "cost_proposals_error": raw.get("cost_proposals_error"),
-        "cost_proposals_error_at": raw.get("cost_proposals_error_at"),
-        "cost_window_days": raw.get("cost_window_days") or 0,
-        # The bounds the recompute ran over. `None` on a cache written before
-        # they were recorded — absent, never guessed from the day count, since
-        # deriving them would invent the very provenance this exists to supply.
-        "cost_since": raw.get("cost_since"),
-        "cost_until": raw.get("cost_until"),
-        "cost_excluded": raw.get("cost_excluded") or {},
-        # The build that computed these proposals. `None` on a cache written
-        # before the stamp existed — absent, never the running build, which
-        # would assert agreement about figures we cannot vouch for.
-        #
-        # This is the SECOND whitelist a `cost_*` key has to be named in (the
-        # first is the round-trip list in `write_cache`). Both drop an unnamed
-        # key silently, and the symptom is a field that reads as "never
-        # stamped" rather than an error.
-        "cost_tj_version": raw.get("cost_tj_version"),
-    }
+    # Project by PREFIX rather than a hand-written dict — this used to be the
+    # SECOND whitelist a `cost_*` key had to be named in (the first was the
+    # round-trip loop in `write_cache`, now also prefix-based). Both dropped
+    # an unnamed key silently, and the symptom was a field that read as
+    # "never stamped" rather than an error. Every key the cost-proposal
+    # producer writes is prefixed `cost_`, and `write_cache` never originates
+    # one of its own (see the comment there), so a plain prefix filter over
+    # the raw cache is exactly the cost block.
+    block: dict[str, Any] = {k: v for k, v in raw.items() if k.startswith("cost_")}
+    # Defaulting behavior callers depend on: absent/falsy reads as the empty
+    # value below rather than `None`, so a caller's own `or` chain isn't
+    # needed at every call site.
+    block["cost_proposals"] = block.get("cost_proposals") or []
+    block["cost_window_days"] = block.get("cost_window_days") or 0
+    block["cost_excluded"] = block.get("cost_excluded") or {}
+    # Stable shape: these read as `None` (never guessed/derived) on a cache
+    # written before the field existed, same as before prefix-projection.
+    for key in (
+        "cost_computed_at", "cost_proposals_error", "cost_proposals_error_at",
+        "cost_since", "cost_until", "cost_tj_version",
+    ):
+        block.setdefault(key, None)
+    return block
 
 
 def write_cost_proposals_error(

--- a/tokenjam/core/optimize/scan_cycle.py
+++ b/tokenjam/core/optimize/scan_cycle.py
@@ -64,10 +64,33 @@ It is a READ cadence and no surface may drive a scan cycle from it. Doing so
 put a full-corpus pass on a five-minute timer against passes that take minutes,
 which is most of a duty cycle of continuous scanning; the surfaces now re-read
 on that timer and the daemon owns when scanning happens.
+
+GATED ON INGESTION, NOT THE WALL CLOCK ALONE. The interval job used to fire
+this cycle on a pure timer, so an idle machine recomputed an answer that could
+not have changed — several minutes of full-corpus analysis, including the
+relearn distill pass's LLM subprocess calls, on zero new telemetry.
+``core/optimize/ingest_watermark.py`` is a cheap in-process counter bumped at
+the two DuckDB write paths every ingestion source funnels through. A
+SCHEDULED tick (the interval job, and the startup kick — which always passes,
+since this process has no prior watermark to compare against) now also
+requires ``[optimize] scan_watermark_min_new_spans`` new spans since the last
+pass that actually ran; below it, the tick is a no-op, same shape as
+``scan_enabled`` or the overlap guard declining. The floor against thrash is
+structural rather than a second timer: the watermark baseline only advances
+when a pass actually completes, and this function can fire no more often than
+the scheduler's own interval, so two passes can never land back-to-back
+faster than ``scan_interval_hours`` apart. The ceiling,
+``scan_watermark_max_staleness_hours``, forces a tick to run regardless of the
+watermark once that long has passed since the last pass — a quiet machine
+still gets refreshed occasionally rather than never again. An explicit
+user-triggered rescan (``POST /optimize/rescan``) passes ``force=True`` and
+bypasses this gate entirely — a human asking is answered, not deferred to the
+next tick.
 """
 from __future__ import annotations
 
 import threading
+from datetime import timedelta
 from typing import Any, Callable
 
 # THE CYCLE'S OWN IN-FLIGHT FLAG — the whole pass, not one of the stores it
@@ -100,6 +123,61 @@ def is_cycle_computing() -> bool:
     return _CYCLE_COMPUTING.is_set()
 
 
+# WATERMARK STATE FOR THE SCHEDULED-TICK GATE. ``None``/``None`` means "no
+# pass has completed in this process yet" — deliberately the state right
+# after a fresh `tj serve` boot, so the first tick (interval or startup kick)
+# always proceeds rather than comparing against a watermark it has no history
+# for. Set once, from `_job()`'s own success path, never read+cleared like
+# `_CYCLE_COMPUTING` — a declined/failed pass must leave the last SUCCESSFUL
+# watermark in place so the next tick's delta is still measured from real
+# ground truth.
+_watermark_lock = threading.Lock()
+_last_pass_watermark: int | None = None
+_last_pass_at: Any = None
+
+
+def _record_pass_watermark(watermark: int) -> None:
+    from tokenjam.utils.time_parse import utcnow
+
+    global _last_pass_watermark, _last_pass_at
+    with _watermark_lock:
+        _last_pass_watermark = watermark
+        _last_pass_at = utcnow()
+
+
+def _should_run_scheduled_pass(config: Any) -> bool:
+    """Gate for a SCHEDULED tick only. An explicit rescan never calls this.
+
+    True when: no pass has completed yet in this process; the corpus has
+    grown by at least ``scan_watermark_min_new_spans`` since the last one
+    that did; or the last one is older than
+    ``scan_watermark_max_staleness_hours`` (the ceiling — forces a refresh on
+    a quiet machine regardless of the watermark).
+    """
+    from tokenjam.core.optimize import ingest_watermark
+    from tokenjam.utils.time_parse import utcnow
+
+    with _watermark_lock:
+        last_watermark = _last_pass_watermark
+        last_at = _last_pass_at
+
+    if last_watermark is None or last_at is None:
+        return True
+
+    optimize = getattr(config, "optimize", None)
+    min_new_spans = int(getattr(optimize, "scan_watermark_min_new_spans", 1))
+    max_staleness_hours = float(
+        getattr(optimize, "scan_watermark_max_staleness_hours", 24.0)
+    )
+
+    if max_staleness_hours > 0 and utcnow() - last_at >= timedelta(hours=max_staleness_hours):
+        return True
+
+    if min_new_spans <= 0:
+        return True
+    return (ingest_watermark.current() - last_watermark) >= min_new_spans
+
+
 def scan_enabled(config: Any) -> bool:
     """Whether the daemon may scan on its own at all.
 
@@ -112,7 +190,7 @@ def scan_enabled(config: Any) -> bool:
 
 
 def trigger_scan_cycle(
-    backend_factory: Callable[[], Any], config: Any,
+    backend_factory: Callable[[], Any], config: Any, *, force: bool = False,
 ) -> dict[str, bool]:
     """Refresh every analyzer store. Returns which passes actually STARTED.
 
@@ -121,6 +199,15 @@ def trigger_scan_cycle(
     bind path. A ``False`` in the result means that store's own overlap guard
     declined — a pass was already in flight — which is a no-op, not a failure.
 
+    ``force=False`` (the default — every SCHEDULED caller, i.e. the interval
+    job and the startup kick) is additionally gated by
+    ``_should_run_scheduled_pass``: an idle machine with no new spans since
+    the last pass is answered with ``{"analyzer_pass": False}`` before
+    anything is dispatched — see this module's docstring, "GATED ON
+    INGESTION". ``force=True`` is reserved for an explicit user rescan
+    (``POST /optimize/rescan``), which must always attempt a pass — a human
+    asking is never deferred to the next tick.
+
     Never raises. One store failing to start must not stop the other two from
     refreshing; a store that raises on trigger is reported as not started and
     its own error channel records why (each recompute stores its exception so
@@ -128,6 +215,9 @@ def trigger_scan_cycle(
     no explanation).
     """
     from tokenjam.utils.time_parse import utcnow
+
+    if not force and not _should_run_scheduled_pass(config):
+        return {"analyzer_pass": False}
 
     # Resolved ONCE, before anything is dispatched, so every pass in this cycle
     # subtracts its window from the same instant.
@@ -159,12 +249,17 @@ def _trigger_analyzer_pass(
     Returns ``False`` when the report store's own overlap guard declined, which
     means a pass is already in flight and this cycle is a no-op.
     """
-    from tokenjam.core.optimize import cost_proposals, report_store
+    from tokenjam.core.optimize import cost_proposals, ingest_watermark, report_store
 
     if report_store.is_computing() or is_cycle_computing():
         return False
 
     def _job() -> None:
+        # Read BEFORE the pass runs, not after: a span landing WHILE this pass
+        # is in flight is not covered by what it analyzed, so it must still
+        # count toward the next tick's delta. Recording a post-pass value
+        # would silently consume that span's contribution to the watermark.
+        watermark_at_start = ingest_watermark.current()
         backend = None
         try:
             backend = backend_factory()
@@ -172,6 +267,7 @@ def _trigger_analyzer_pass(
             if stored is None:
                 # The overlap guard declined between the check above and here.
                 return
+            _record_pass_watermark(watermark_at_start)
             # The typed report the pass just wrote. `None` when the stored
             # payload cannot be rehydrated (corrupt, or written by a newer
             # producer); the downstream stores then fall back to computing

--- a/tokenjam/core/transcript_sync.py
+++ b/tokenjam/core/transcript_sync.py
@@ -52,6 +52,8 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
+from tokenjam.core.distill import is_tokenjam_invoke_cwd
+
 logger = logging.getLogger(__name__)
 
 
@@ -173,17 +175,20 @@ def _parse_ts(value: object) -> datetime | None:
     return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
 
 
-def _header_fields(path: Path) -> tuple[str | None, datetime | None]:
-    """Read the internal ``sessionId`` + first timestamp out of a transcript's
-    leading records WITHOUT parsing the whole file.
+def _header_fields(path: Path) -> tuple[str | None, datetime | None, str | None]:
+    """Read the internal ``sessionId`` + first timestamp + ``cwd`` out of a
+    transcript's leading records WITHOUT parsing the whole file.
 
     Deriving the id from content is the entire point: a nested
     ``subagents/agent-*.jsonl`` file has its own filename but its parent's
     ``sessionId``, so keying on the filename double-counts it as a separate
-    session.
+    session. ``cwd`` is read the same way so ``scan_disk_sessions`` can
+    exclude tokenjam's own internal model calls (see
+    ``core.distill.is_tokenjam_invoke_cwd``) without a second file open.
     """
     session_id: str | None = None
     started_at: datetime | None = None
+    cwd: str | None = None
     try:
         with path.open("r", encoding="utf-8", errors="replace") as fh:
             for index, line in enumerate(fh):
@@ -204,12 +209,16 @@ def _header_fields(path: Path) -> tuple[str | None, datetime | None]:
                         session_id = candidate
                 if started_at is None:
                     started_at = _parse_ts(record.get("timestamp"))
-                if session_id is not None and started_at is not None:
+                if cwd is None:
+                    candidate_cwd = record.get("cwd")
+                    if isinstance(candidate_cwd, str) and candidate_cwd:
+                        cwd = candidate_cwd
+                if session_id is not None and started_at is not None and cwd is not None:
                     break
     except OSError as exc:
         logger.debug("could not read transcript header %s: %s", path, exc)
-        return None, None
-    return session_id, started_at
+        return None, None, None
+    return session_id, started_at, cwd
 
 
 def scan_disk_sessions(
@@ -240,9 +249,16 @@ def scan_disk_sessions(
             if mtime < since:
                 continue
         scanned += 1
-        session_id, started_at = _header_fields(path)
+        session_id, started_at, cwd = _header_fields(path)
         if not session_id:
             unreadable += 1
+            continue
+        if is_tokenjam_invoke_cwd(cwd):
+            # tokenjam's own distill/presence model calls, not a session the
+            # user worked — see core.distill.is_tokenjam_invoke_cwd. Excluded
+            # here too (not just core.backfill's parse loop) so this reader,
+            # used by the reconciliation gap report, never counts one as
+            # "missing" and pulls it in via a catch-up backfill.
             continue
         try:
             project = path.relative_to(root).parts[0]


### PR DESCRIPTION
Four independent defects in the relearn analyzer and the machinery around it. Each is its own commit; they are grouped because they share the same three modules and were verified together against one live corpus.

## 1. Text-less error spans no longer reach the model, or merge with each other

An OTEL error span whose `status_message` is empty fell back to the span's own **name** as its error text, so `error_text` became the literal string `gen_ai.tool.call`. Every unrelated failure carrying that non-error then shared a signature and merged into one cluster.

Those merged spans were being handed to the distill pass, which — given no error text at all — still produced a confident diagnosis. On a real 6,584-session corpus this surfaced as three LLM-titled clusters ("Tool Invocation Framework Error", 120 sessions, $23.00; "WebFetch Tool Generic Repeated Error", $4.89; "Tool Call Permission Not Configured", $3.98) whose every recorded example snippet was the string `gen_ai.tool.call`. About $32 of a $368 headline was a bag of unrelated failures wearing an invented root cause, and model calls were being spent to invent it.

- `FailureEpisode` now records whether its error text came from the name fallback, set at both extractor sites rather than re-derived downstream by string comparison.
- Such a failure's signature is scoped to its own session, so unrelated failures can no longer merge and the group can never clear the recurrence threshold. Their cost is still counted, in the existing below-threshold residue.
- A second, independent gate rejects an all-name-fallback cluster inside the distill evidence check, so the suppression does not rest on the signature change alone.
- The test that pinned the old fallback behaviour is rewritten to assert the new contract rather than deleted.

## 2. Three cache paths escaped `--projects-root` / `--db` scoping

The scoping contract promises a scoped or demo run does not write the operator's real machine state. Three paths ignored it, and the write fires only after a successful model call, so it was invisible in the common path and in tests.

- `distill._default_cache_dir()` hardcoded `~/.tj/distill_cache` with no config parameter at all. It now routes through the same storage-base helper the relearn store, report store, and transcript cache already use, keeping the old location as the no-config fallback.
- The session-title distill **API route** called the cache helpers with no cache directory whatsoever — a served route writing to the real home regardless of scope. It now threads the request's config.
- `apply_distill_to_residual`'s cache directory is now required rather than defaulting to the unscoped resolver, so the safe path is not something every caller has to remember.

Tests mirror the existing fake-HOME isolation precedent; none existed for any of these three.

## 3. The tool's own model calls are no longer ingested as user sessions

The distill and rule-presence paths invoke the local `claude` binary, which writes a transcript to disk, which ingestion then read back as an ordinary coding session. On the corpus this was verified against, **1,010 of 6,972 sessions — 14.5% — were the tool measuring itself.** The dollar contamination was negligible; the session-count contamination was not, since per-session denominators, persona classification and cohort counts all run over that population.

Rather than guess at a fingerprint from fields no parser reads, the invocation now runs from a dedicated, explicitly-named marker subdirectory of the temp root, and both on-disk readers exclude sessions recorded against it. A user genuinely working in a temp directory is unaffected — only the exact marker directory is excluded.

## 4. The shared cost cache stops dropping keys it was never told about

The relearn detector and the cost proposals share one cache file, and a `cost_`-prefixed key had to be named in two separate hand-written lists to survive a round trip — one in the write path's preservation branch, one in the read path's projection. A key missing from either was dropped with no error, and read downstream as a legitimate "absent".

It had already eaten two keys. A third was live: a recorded cost-proposals **error** was silently erased by any relearn-leg rewrite, so a failed recompute read back as though nothing had gone wrong. Both lists are replaced by prefix copy-through, with the existing defaulting behaviour preserved for the callers that rely on it. The new test round-trips a key that appears nowhere in the source, so the guard cannot pass by whitelist coincidence.

## 5. The scheduled analyzer pass no longer re-spends on an idle machine

The daemon ran the full pass — model calls attached — on a plain wall-clock interval with no reference to whether any new telemetry had arrived, so a machine where nothing happened still recomputed an answer that could not have changed. Catch-up ingestion was already a separate, independently-scheduled job with no coupling to it.

A span counter bumped at the two database write choke points now gates the scheduled pass. A staleness ceiling guarantees a quiet machine still refreshes, an explicit user rescan always runs regardless, and the anti-thrash floor is structural: the gate is only ever evaluated on the scheduler's own interval, so two passes cannot land closer together than that.

---

Verified against the current code and a live corpus before implementation; several details in the original problem reports turned out to be stale and were corrected rather than carried forward. Analyzer thresholds, the finding's field set, the render contract, and the persisted cache schema are all unchanged.
