### PR TITLE
Remove verified-redundant tests, preserve two boundary assertions

### DIFF
--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -640,24 +640,6 @@ async def test_status_response_includes_framing_block(db, client):
     assert _FRAMING_KEYS <= set(data["framing"])
 
 
-@pytest.mark.parametrize("plan_tier,expected_mode", [
-    ("max_5x", "subscription"),
-    ("api", "api"),
-    ("local", "local"),
-    ("unknown", "unknown"),
-])
-async def test_status_framing_reflects_plan_tier(
-    db, client, monkeypatch, tmp_path, plan_tier, expected_mode,
-):
-    """The /status framing pricing_mode tracks the session plan tier (#191).
-    HOME is isolated so the unknown case can't pick up this machine's global
-    ~/.config/tj plan via compute_framing's config fallback."""
-    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
-    _seed_trace_with_plan(db, plan_tier, trace_id="ee" * 16, session_id="sess-191")
-    framing = (await client.get("/api/v1/status")).json()["framing"]
-    assert framing["pricing_mode"] == expected_mode
-
-
 # --- #2: /sessions/{id} carries a framing block so SessionDetailView's ------- #
 # --- Overview / subagents / traces cost cells reframe subscription/local. ----- #
 async def test_session_detail_includes_framing_block(db, client):
@@ -791,17 +773,6 @@ async def test_reuse_clusters_endpoint_returns_finding_and_skeleton_text(db):
     assert "planning_texts" in data
     assert any(v for v in data["planning_texts"].values())
     assert data["pricing_mode"] in ("api", "subscription", "local", "unknown")
-
-
-async def test_optimize_response_includes_framing_block(client, db, config):
-    await _ingest_sample_span(client)
-    _warm_scan(db, config)
-    resp = await client.get("/api/v1/optimize?since=30d")
-    assert resp.status_code == 200
-    data = resp.json()
-    if data.get("error") == "no_data":
-        pytest.skip("no spans landed for optimize in this fixture")
-    assert _FRAMING_KEYS <= set(data["framing"])
 
 
 async def test_optimize_response_always_carries_downgrade_key(client, db, config):
@@ -1111,12 +1082,6 @@ async def test_get_endpoint_works_with_valid_api_key(auth_client):
     )
     assert resp.status_code == 200
 
-
-# ── Docs endpoint ──────────────────────────────────────────────────────────
-
-async def test_docs_endpoint_is_accessible(client):
-    resp = await client.get("/docs")
-    assert resp.status_code == 200
 
 
 # ── agent_id normalization ─────────────────────────────────────────────────

--- a/tests/integration/test_demos.py
+++ b/tests/integration/test_demos.py
@@ -17,13 +17,6 @@ def test_demo_list_shows_all_scenarios():
     assert "hallucination-drift" in result.output
 
 
-def test_demo_list_shows_descriptions():
-    runner = CliRunner()
-    result = runner.invoke(cli, ["demo"])
-    assert result.exit_code == 0
-    assert len(result.output.strip()) > 0
-
-
 def test_demo_retry_loop_exits_zero():
     runner = CliRunner()
     result = runner.invoke(cli, ["demo", "retry-loop"])

--- a/tests/integration/test_tokenmaxx_serve.py
+++ b/tests/integration/test_tokenmaxx_serve.py
@@ -127,14 +127,3 @@ def test_tokenmaxx_cli_json_through_serve(tmp_path, monkeypatch):
     db.close()
 
 
-def test_tokenmaxx_cli_errors_cleanly_without_serve_or_conn():
-    """A backend that is neither a live conn nor an ApiBackend → clean error."""
-    class _Dummy:  # no .conn, not an ApiBackend
-        pass
-
-    result = CliRunner().invoke(
-        cmd_tokenmaxx, ["--since", "30d"],
-        obj={"db": _Dummy(), "config": _config(), "agent": None},
-    )
-    assert result.exit_code != 0
-    assert "tj serve" in result.output

--- a/tests/unit/test_demo_live.py
+++ b/tests/unit/test_demo_live.py
@@ -7,7 +7,6 @@ from tokenjam.core.models import NormalizedSpan, SpanKind, SpanStatus
 from tokenjam.demo.live import (
     LiveReplayError,
     LiveSink,
-    _build_payload,
     _span_to_otlp,
     build_sink,
     check_serve_alive,
@@ -76,14 +75,6 @@ def test_span_to_otlp_preserves_tool_input_and_error():
     assert parsed.attributes.get(GenAIAttributes.TOOL_INPUT) == json.dumps({"query": "x"})
 
 
-def test_build_payload_shape():
-    payload = _build_payload([_span_to_otlp(_llm_span())])
-    assert "resourceSpans" in payload
-    spans = payload["resourceSpans"][0]["scopeSpans"][0]["spans"]
-    assert len(spans) == 1
-    assert spans[0]["name"] == "gen_ai.llm.call"
-
-
 def test_live_sink_attaches_bearer_only_with_secret():
     with_secret = LiveSink("http://x/api/v1/spans", "s3cret")
     assert with_secret._headers.get("Authorization") == "Bearer s3cret"
@@ -119,7 +110,10 @@ def test_live_sink_buffers_and_flushes(monkeypatch):
     assert result.ingested == 2
     assert sink.pending == 0  # buffer cleared after flush
     assert captured["url"] == "http://serve/api/v1/spans"
-    assert len(captured["payload"]["resourceSpans"][0]["scopeSpans"][0]["spans"]) == 2
+    sent_spans = captured["payload"]["resourceSpans"][0]["scopeSpans"][0]["spans"]
+    assert len(sent_spans) == 2
+    # The wire payload carries each span's real name through _build_payload.
+    assert {s["name"] for s in sent_spans} == {"gen_ai.llm.call", "gen_ai.tool.call"}
 
 
 def test_live_sink_flush_raises_on_401(monkeypatch):

--- a/tests/unit/test_export_claude_code.py
+++ b/tests/unit/test_export_claude_code.py
@@ -32,6 +32,12 @@ def _sample_finding() -> DowngradeFinding:
     )
 
 
+# `estimated_savings_usd_month` is written unconditionally (dollars are always
+# legitimate); pricing_mode/plan_tier only echo back as metadata text and no
+# longer gate which fields appear, so one representative mode covers all three
+# (product decision: tj no longer differentiates export output between
+# subscription and API users).
+
 def test_render_api_user_carries_usd_savings():
     snippet = render_claude_code_snippet(
         downgrade=_sample_finding(),
@@ -41,36 +47,6 @@ def test_render_api_user_carries_usd_savings():
     assert "estimated_savings_usd_month" in snippet
     assert "42.5" in snippet
     # Subscription-only field should NOT appear
-    assert "estimated_tokens_freed" not in snippet
-
-
-def test_render_subscription_user_carries_usd_savings_too():
-    """Subscription users now see the same `estimated_savings_usd_month`
-    field an API user would (product decision: dollars are always
-    legitimate, so tj no longer differentiates its export output between
-    subscription and API users). Previously this carried
-    `estimated_tokens_freed` instead."""
-    snippet = render_claude_code_snippet(
-        downgrade=_sample_finding(),
-        pricing_mode="subscription",
-        plan_tier="max_20x",
-    )
-    assert "estimated_savings_usd_month" in snippet
-    assert "42.5" in snippet
-    assert "estimated_tokens_freed" not in snippet
-
-
-def test_render_unknown_plan_carries_usd_savings_too():
-    """Unknown plan tier now also carries `estimated_savings_usd_month`
-    (previously a reconfigure-hint note with no figure at all), same
-    product-decision reasoning as the subscription case above."""
-    snippet = render_claude_code_snippet(
-        downgrade=_sample_finding(),
-        pricing_mode="unknown",
-        plan_tier="unknown",
-    )
-    assert "estimated_savings_usd_month" in snippet
-    assert "42.5" in snippet
     assert "estimated_tokens_freed" not in snippet
 
 

--- a/tests/unit/test_export_route_generators.py
+++ b/tests/unit/test_export_route_generators.py
@@ -127,28 +127,6 @@ def test_api_user_carries_usd_savings(render):
     assert "estimated_tokens_freed" not in body
 
 
-@pytest.mark.parametrize("render", [render_ccr_config, render_litellm_config])
-def test_subscription_user_carries_usd_savings_too(render):
-    body = render(
-        downgrade=_sample_finding(), pricing_mode="subscription", plan_tier="max_20x",
-        since="30d", until="2026-06-22",
-    )
-    assert "estimated_savings_usd_month" in body
-    assert "42.5" in body
-    assert "estimated_tokens_freed" not in body
-
-
-@pytest.mark.parametrize("render", [render_ccr_config, render_litellm_config])
-def test_unknown_plan_carries_usd_savings_too(render):
-    body = render(
-        downgrade=_sample_finding(), pricing_mode="unknown", plan_tier="unknown",
-        since="30d", until="2026-06-22",
-    )
-    assert "estimated_savings_usd_month" in body
-    assert "42.5" in body
-    assert "estimated_tokens_freed" not in body
-
-
 # --- empty-finding case -----------------------------------------------------
 
 def test_ccr_empty_finding_still_valid_and_carries_caveat():

--- a/tests/unit/test_formatting.py
+++ b/tests/unit/test_formatting.py
@@ -43,6 +43,9 @@ class TestFormatTokens:
     def test_millions_with_fraction(self):
         assert format_tokens(2_500_000) == "2.5M"
 
+    def test_just_below_million(self):
+        assert format_tokens(999_000) == "999.0k"
+
     def test_just_below_billion_stays_millions(self):
         assert format_tokens(999_999_999) == "1000.0M"
 

--- a/tests/unit/test_harness_setup.py
+++ b/tests/unit/test_harness_setup.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from tokenjam.core.harness_setup import (
-    HELPER_RELPATH,
     MAX_SPAWN_HITS,
     build_run_env_helper,
     python_launcher_snippet,
@@ -88,6 +87,3 @@ def test_scan_detects_otel_instrumentation_point(tmp_path):
 def test_scan_missing_dir_returns_empty(tmp_path):
     assert scan_spawn_points(tmp_path / "nope") == []
 
-
-def test_helper_relpath_is_under_tj():
-    assert HELPER_RELPATH.startswith(".tj/")

--- a/tests/unit/test_humanize.py
+++ b/tests/unit/test_humanize.py
@@ -9,22 +9,6 @@ from tokenjam.utils.humanize import display_path, format_tokens
 # --- format_tokens ----------------------------------------------------------
 
 
-def test_format_tokens_sub_thousand_is_raw():
-    assert format_tokens(0) == "0"
-    assert format_tokens(999) == "999"
-
-
-def test_format_tokens_thousands_use_k():
-    assert format_tokens(1_000) == "1.0k"
-    assert format_tokens(42_300) == "42.3k"
-    assert format_tokens(999_000) == "999.0k"
-
-
-def test_format_tokens_millions_use_m():
-    assert format_tokens(1_000_000) == "1.0M"
-    assert format_tokens(2_500_000) == "2.5M"
-
-
 # --- display_path -----------------------------------------------------------
 
 

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -169,11 +169,6 @@ class TestEnums:
         assert Severity.WARNING.value == "warning"
         assert Severity.INFO.value == "info"
 
-    def test_alert_type_values(self):
-        assert AlertType.COST_BUDGET_DAILY.value == "cost_budget_daily"
-        assert AlertType.RETRY_LOOP.value == "retry_loop"
-        assert AlertType.DRIFT_DETECTED.value == "drift_detected"
-
     def test_span_status_values(self):
         assert SpanStatus.OK.value == "ok"
         assert SpanStatus.ERROR.value == "error"

--- a/tests/unit/test_time_parse.py
+++ b/tests/unit/test_time_parse.py
@@ -20,13 +20,6 @@ class TestParseSinceRelative:
             result = parse_since("1h")
             assert result == now - timedelta(hours=1)
 
-    def test_hours_large(self):
-        with patch("tokenjam.utils.time_parse.utcnow") as mock_now:
-            now = datetime(2026, 3, 28, 12, 0, 0, tzinfo=timezone.utc)
-            mock_now.return_value = now
-            result = parse_since("12h")
-            assert result == now - timedelta(hours=12)
-
     def test_days(self):
         with patch("tokenjam.utils.time_parse.utcnow") as mock_now:
             now = datetime(2026, 3, 28, 12, 0, 0, tzinfo=timezone.utc)


### PR DESCRIPTION
## Summary

Verified a list of 45 candidate tests flagged by a prior file-level audit as possibly redundant, and deleted only the ones I could prove were fully subsumed elsewhere by comparing exact input/output assertions. **16 of the 45 candidates verified as genuinely redundant and were deleted (21 pytest test-IDs once parametrize expansion is counted); the other 29 did not hold up under verification and were left in place.** Two deletions required porting one assertion each into the surviving test first, to avoid losing coverage.

This is a test-only change. No product source under `tokenjam/` was touched.

### Deleted (16 candidates, 21 test-IDs)

- `tests/unit/test_humanize.py` (3): `test_format_tokens_sub_thousand_is_raw`, `test_format_tokens_thousands_use_k`, `test_format_tokens_millions_use_m` — `tokenjam/utils/formatting.py` re-exports the identical `format_tokens` function object, already covered by `test_formatting.py::TestFormatTokens`. **Ported:** that survivor was missing the k→M upper boundary (`999_000 == "999.0k"`), so I added `TestFormatTokens.test_just_below_million` before deleting.
- `tests/integration/test_api.py` (3 functions / 6 test-IDs): `test_status_framing_reflects_plan_tier` (a 4-case parametrize) — the `/status` and `/traces` routes wire `compute_framing` via byte-identical code, the `/traces` version of this matrix survives, and `status_response_includes_framing_block` still guards `/status`'s own key presence; `test_docs_endpoint_is_accessible` — a bare FastAPI `/docs` 200 check with no product logic; `test_optimize_response_includes_framing_block` — a strict subset of `test_optimize_chain_framing_and_recoverable_fields` (identical setup, plus more assertions).
- `tests/integration/test_demos.py` (1): `test_demo_list_shows_descriptions` — strictly weaker than `test_demo_list_shows_all_scenarios` (same invocation, `len(output) > 0` vs. specific substrings).
- `tests/integration/test_tokenmaxx_serve.py` (1): `test_tokenmaxx_cli_errors_cleanly_without_serve_or_conn` — subsumed by `tests/unit/test_cmd_tokenmaxx.py::test_requires_direct_db_connection`, whose own comment cross-references this file.
- `tests/unit/test_demo_live.py` (1): `test_build_payload_shape`. **Ported:** its only assertion not covered elsewhere (`spans[0]["name"]` propagating through `_build_payload`) was added as a new assertion inside `test_live_sink_buffers_and_flushes`, which exercises the same payload construction through the real `flush()` path.
- `tests/unit/test_export_claude_code.py` (2): `test_render_subscription_user_carries_usd_savings_too`, `test_render_unknown_plan_carries_usd_savings_too` — verified against source that `render_claude_code_snippet` no longer branches on `pricing_mode`/`plan_tier` for which fields appear (product decision); added a short comment documenting the invariant in place of the deleted docstrings.
- `tests/unit/test_export_route_generators.py` (2 functions / 4 test-IDs, each parametrized over both renderers): `test_subscription_user_carries_usd_savings_too`, `test_unknown_plan_carries_usd_savings_too` — same invariant, verified against both `render_ccr_config` and `render_litellm_config` source.
- `tests/unit/test_harness_setup.py` (1): `test_helper_relpath_is_under_tj` — `HELPER_RELPATH`'s exact value is verified more strongly (exact-match, not just prefix) by `tests/unit/test_mcp_server.py:409` via a real MCP-tool code path.
- `tests/unit/test_models.py` (1): `test_alert_type_values` — all three asserted enum spellings (`cost_budget_daily`, `retry_loop`, `drift_detected`) are independently verified via real serialization in `test_mcp_server.py`, `test_demo_live.py`, and `test_demos.py`.
- `tests/unit/test_time_parse.py` (1): `test_hours_large` — verified in source that `parse_since` has no branch on digit count; identical regex path to `test_hours`.

### Skipped as unverifiable (29 candidates)

The verification bar was: prove every assertion is checked elsewhere, or leave the test in place. 29 of the 45 candidates did not clear that bar. Notable findings where the original audit's premise turned out to be factually wrong on inspection:

- **`tests/integration/test_cli.py` (2):** `test_doctor_onboarding_signal_info_when_silent` / `_ok_with_spans` are the *only* tests proving `cmd_doctor.py`'s `checks.append(_check_onboarding_first_signal(...))` line is wired into `tj doctor --json`'s output — the claimed unit-test survivors only call the check function directly, never through the CLI's ~20-line manually-maintained checks list.
- **`tests/integration/test_summarize_cli.py` (5):** each "human-output" test exercises a distinct call site of a shared print helper (`_print_verdict`, `_print_amortization`) with its own independent wiring; no unit test covers the actual rendered text at all. One candidate (`test_prep_via_api_unknown_model_labels_estimate`) covers a fallback branch (`rates_known=False`) that literally no other test reaches.
- **`tests/unit/test_drift.py` (1):** the claimed synthetic-test survivor always registers an explicit `AgentConfig` for the test agent, so it never exercises `drift.py:232`'s `self.config.agents.get(agent_id) or AgentConfig()` fallback that the candidate is testing.
- **`tests/unit/test_onboard_first_run.py` (4):** one candidate's own docstring starts with "Regression:" — a hard no-touch per this suite's convention regardless of audit findings — and it uniquely guards four legacy-panel strings. A second candidate's claimed premise ("prompt was permanently removed") is false; I read the source and the guarded code is still live, gated by an `if persona == "claude-code": return` that this test protects.
- **`tests/unit/test_formatting.py` (4):** the audit's own stated reasoning ("one representative + fallback is enough") contradicts its "drop all 4" instruction, and no other test anywhere references `severity_colour`.
- **`tests/unit/test_models.py` (5 of 6):** only `AlertType`'s literal spelling is verified elsewhere via real JSON output; `Severity`, `SpanStatus.UNSET`, `SpanKind`, and both `isinstance(_, str)` checks are only ever compared enum-to-enum elsewhere, never enum-to-literal.

Full per-file reasoning is in the worker session; ask if you want it broken out further.

## Test plan

- [x] Ran each touched file's tests individually — 270 passed.
- [x] Ran the full suite (`tests/unit/ tests/synthetic/ tests/agents/ tests/integration/`, `-n auto`) before (via `git stash`) and after: 5196 total test-IDs before, 5176 after — a net of -20, reconciling exactly against the ledger above (21 deleted, 1 ported/added).
- [x] One pre-existing failure (`test_onboard_first_run.py::test_home_when_db_populated_but_no_config_is_set_up`) reproduces identically on unmodified `main` and in a file this PR never touches — confirmed flaky/order-dependent, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
