### PR TITLE
perf(status): tj status ran 12 analyzers inline for its footer line

### DIFF
--- a/tests/unit/test_cmd_status_teaser.py
+++ b/tests/unit/test_cmd_status_teaser.py
@@ -2,11 +2,20 @@
 
 Nothing in `tj status`, `tj doctor`, `tj statusline`, or the banner ever
 pointed at `tj optimize` — a user could run tokenjam for months without
-learning the command exists. `build_report` is monkeypatched here rather
-than seeded through real analyzer thresholds: the teaser is a thin
-aggregation layer over the existing #111 recoverable contract, and what's
-under test is that aggregation + the honesty/silence gates around it, not
-the analyzers themselves (those have their own tests).
+learning the command exists.
+
+The teaser READS THE STORED ANALYZER REPORT; it never runs an analyzer. It
+used to call `build_report` inline on every plain `tj status`, which cost
+roughly a minute of CPU on a real corpus before the status table's own
+figures could be printed. `test_status_command_cannot_reach_build_report`
+below is the regression pin for that, and
+`core/optimize/report_store.py`'s module docstring is the rule it enforces.
+
+`report_store.stored_report` is monkeypatched in the aggregation tests rather
+than seeded through real analyzer thresholds: what's under test is the
+aggregation + the honesty/silence gates around it, not the analyzers
+themselves (those have their own tests). The cold-store test uses a real
+config and a real, genuinely empty store directory.
 
 The teaser used to gate on the user's plan tier (`plan_tier_mix` +
 `pricing_mode_for`), staying silent for subscription/local plans. That gate
@@ -16,39 +25,49 @@ teaser now fires for any plan tier with a large-enough recoverable figure.
 """
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 
 from tokenjam.cli.cmd_status import _recoverable_teaser
+from tokenjam.core.config import TjConfig
 
 
-class _FakeDB:
-    def __init__(self, conn):
-        self.conn = conn
-
-
-def _report(*, downgrade_usd=None, finding_usd=None):
-    findings = {}
+def _report(*, downgrade_usd=None, finding_usd=None, findings=None):
+    built = {}
     if finding_usd is not None:
-        findings["cache"] = SimpleNamespace(past_overspend_usd=finding_usd)
+        built["cache"] = SimpleNamespace(past_overspend_usd=finding_usd)
+    if findings:
+        built.update(findings)
     downgrade = None
     if downgrade_usd is not None:
         downgrade = SimpleNamespace(past_overspend_usd=downgrade_usd)
-    return SimpleNamespace(downgrade=downgrade, findings=findings)
+    return SimpleNamespace(downgrade=downgrade, findings=built)
+
+
+def _stored(monkeypatch, report):
+    monkeypatch.setattr(
+        "tokenjam.core.optimize.report_store.stored_report",
+        lambda config=None, **kw: report,
+    )
+
+
+def _config(tmp_path: Path) -> TjConfig:
+    """A real config whose store directory is a real, empty tmp dir."""
+    cfg = TjConfig(version="1")
+    cfg.storage.path = str(tmp_path / "telemetry.duckdb")
+    return cfg
 
 
 def test_teaser_prints_largest_single_estimate_not_a_sum(monkeypatch):
     """The teaser must mirror `largest_recoverable_usd` in api/routes/cost.py:
-    downsize and cache price OVERLAPPING angles on the same spans (#111), so
+    downsize and cache price OVERLAPPING angles on the same spans, so
     summing 2.0 + 3.5 into "$5.50" would print an inflated, non-additive
     headline the product's own API disclaims via `recoverable_additive: False`
     and `_recoverable_overlap_note`. The honest figure is the larger of the
     two on its own: $3.50."""
-    monkeypatch.setattr(
-        "tokenjam.core.optimize.build_report",
-        lambda **kw: _report(downgrade_usd=2.0, finding_usd=3.5),
-    )
+    _stored(monkeypatch, _report(downgrade_usd=2.0, finding_usd=3.5))
 
-    out = _recoverable_teaser(_FakeDB(conn=object()), config=object())
+    out = _recoverable_teaser(config=object())
 
     assert out is not None
     assert "$3.50" in out
@@ -57,18 +76,24 @@ def test_teaser_prints_largest_single_estimate_not_a_sum(monkeypatch):
 
 
 def test_teaser_silent_below_minimum_threshold(monkeypatch):
-    monkeypatch.setattr(
-        "tokenjam.core.optimize.build_report",
-        lambda **kw: _report(finding_usd=0.42),
-    )
+    _stored(monkeypatch, _report(finding_usd=0.42))
 
-    assert _recoverable_teaser(_FakeDB(conn=object()), config=object()) is None
+    assert _recoverable_teaser(config=object()) is None
 
 
-def test_teaser_silent_without_direct_db_connection():
-    """Daemon holds the write lock (API-shim mode) — no `.conn` to build a
-    report from. Must stay silent, never raise."""
-    assert _recoverable_teaser(_FakeDB(conn=None), config=object()) is None
+def test_teaser_reads_store_without_a_direct_db_connection(monkeypatch):
+    """The daemon holding the write lock (API-shim mode, no `.conn`) used to
+    silence the teaser, because it had no connection to run analyzers over.
+    Reading a stored figure needs no connection at all — and that mode is
+    precisely when the store IS warm, since the daemon is what fills it. The
+    teaser takes no `db` argument any more; this pins that the figure still
+    renders when there is no local DB handle in play."""
+    _stored(monkeypatch, _report(finding_usd=12.0))
+
+    out = _recoverable_teaser(config=object())
+
+    assert out is not None
+    assert "$12.00" in out
 
 
 def test_teaser_shows_for_subscription_plan_too(monkeypatch):
@@ -76,22 +101,82 @@ def test_teaser_shows_for_subscription_plan_too(monkeypatch):
     (product decision, reversing the prior subscription/local silence):
     dollars are always legitimate, so a subscription-tier user with a large
     recoverable total gets the same dollar teaser an API user would."""
-    monkeypatch.setattr(
-        "tokenjam.core.optimize.build_report",
-        lambda **kw: _report(finding_usd=50.0),
-    )
+    _stored(monkeypatch, _report(finding_usd=50.0))
 
-    out = _recoverable_teaser(_FakeDB(conn=object()), config=object())
+    out = _recoverable_teaser(config=object())
     assert out is not None
     assert "$50.00" in out
     assert "tj optimize" in out
 
 
-def test_teaser_silent_on_build_report_failure(monkeypatch):
+def test_teaser_silent_on_store_read_failure(monkeypatch):
     """Never let the teaser computation break `tj status` itself."""
-    def boom(**kw):
-        raise RuntimeError("optimize requires a direct DuckDB connection")
+    def boom(config=None, **kw):
+        raise RuntimeError("store unreadable")
+
+    monkeypatch.setattr("tokenjam.core.optimize.report_store.stored_report", boom)
+
+    assert _recoverable_teaser(config=object()) is None
+
+
+def test_teaser_scopes_the_figure_to_cost_analyzers(monkeypatch):
+    """The store holds EVERY analyzer's finding, not just the cost rail's, so
+    the `COST_ANALYZERS` scoping the teaser has always claimed now has to be
+    applied on the read. A finding under a name outside that set must not be
+    able to become the headline."""
+    _stored(monkeypatch, _report(
+        finding_usd=4.0,
+        findings={"not-a-cost-analyzer": SimpleNamespace(past_overspend_usd=999.0)},
+    ))
+
+    out = _recoverable_teaser(config=object())
+
+    assert out is not None
+    assert "$4.00" in out
+    assert "999" not in out
+
+
+def test_cold_store_renders_a_command_and_no_figure(tmp_path):
+    """A store that has never been written is COLD, not zero. `$0.00
+    recoverable` off a scan that never ran reads as "you have no waste",
+    which is a reassurance the data does not support (root anti-pattern 22).
+    The line may name the command that would produce a figure; it may not
+    state a quantity."""
+    out = _recoverable_teaser(config=_config(tmp_path))
+
+    assert out is not None
+    assert "tj optimize" in out
+    assert "$" not in out
+    assert "0" not in out
+    assert "not been scanned" in out
+
+
+def test_status_command_cannot_reach_build_report(monkeypatch, tmp_path):
+    """THE regression pin. `build_report` dispatches every cost analyzer over
+    the whole corpus, including the unbounded `relearn` scan; running it on a
+    plain `tj status` cost about a minute of CPU per invocation. The status
+    module must not be able to reach it at all — so it is neither named in
+    the source nor callable from the teaser, even with a warm store."""
+    from tokenjam.cli import cmd_status
+
+    # The docstring explains WHY the call is gone, so match the CALL form
+    # rather than the bare name.
+    source = Path(cmd_status.__file__).read_text(encoding="utf-8")
+    assert "build_report(" not in source
+
+    def boom(*a, **kw):
+        raise AssertionError("tj status must never dispatch an analyzer")
 
     monkeypatch.setattr("tokenjam.core.optimize.build_report", boom)
+    monkeypatch.setattr("tokenjam.core.optimize.runner.build_report", boom)
+    _stored(monkeypatch, _report(finding_usd=7.0))
 
-    assert _recoverable_teaser(_FakeDB(conn=object()), config=object()) is None
+    out = _recoverable_teaser(config=object())
+    assert out is not None
+    assert "$7.00" in out
+
+    # And cold, with the same trap armed.
+    monkeypatch.undo()
+    monkeypatch.setattr("tokenjam.core.optimize.build_report", boom)
+    monkeypatch.setattr("tokenjam.core.optimize.runner.build_report", boom)
+    assert "$" not in (_recoverable_teaser(config=_config(tmp_path)) or "")

--- a/tokenjam/cli/cmd_status.py
+++ b/tokenjam/cli/cmd_status.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-from datetime import timedelta
 
 import click
 from rich.markup import escape
@@ -18,13 +17,19 @@ from tokenjam.utils.formatting import (
 )
 from tokenjam.utils.time_parse import utcnow
 
-#: Window the recoverable teaser looks back over, matching `tj optimize`'s
-#: own `--since` default so the figure means the same thing in both places.
-_TEASER_WINDOW_DAYS = 30
-
 #: Below this, "$X recoverable" reads as noise rather than a real pointer —
 #: stay silent instead of printing a sub-dollar figure.
 _TEASER_MIN_USD = 1.0
+
+#: What the teaser says when the analyzer report store has never been written.
+#: A COLD store is not zero and not "nothing to recover" — it carries no figure
+#: at all, so this line names the command that produces one and states no
+#: quantity. `tj optimize` runs the scan in the foreground and prints the real
+#: figures; the daemon writes the store on its own schedule.
+_COLD_TEASER = (
+    "[dim]Recoverable waste has not been scanned yet: run "
+    "[bold]tj optimize[/bold].[/dim]"
+)
 
 
 @click.command("status", cls=TjCommand, status_message="Scanning your sessions…")
@@ -164,21 +169,33 @@ def cmd_status(
                 f"Run [bold]tj onboard --claude-code --reconfigure[/bold] "
                 f"(or [bold]--codex[/bold]) to set it.[/dim]"
             )
-        teaser = _recoverable_teaser(db, ctx.obj.get("config"))
+        teaser = _recoverable_teaser(ctx.obj.get("config"))
         if teaser:
             console.print(teaser)
 
     ctx.exit(1 if has_active_alerts else 0)
 
 
-def _recoverable_teaser(db, config) -> str | None:
+def _recoverable_teaser(config) -> str | None:
     """One-line `tj optimize` pointer for `tj status` — nothing in status,
     doctor, statusline or the banner ever mentioned optimize existed.
 
+    READS THE STORE, NEVER RUNS AN ANALYZER. This used to call `build_report`
+    inline on every plain `tj status`, which dispatched the whole cost
+    analyzer set (including the deliberately unbounded `relearn` scan) over
+    the entire corpus and cost about a minute of CPU before the command
+    returned. That is the identical failure `core/optimize/report_store.py`
+    was written to end on the HTTP side ("no request path runs an analyzer");
+    a CLI command that a user types to read a status table is the same kind of
+    path. Analyzer runs happen at daemon boot, on the daemon's schedule, on a
+    user Rescan, or when the user explicitly types `tj optimize` — and they
+    all land in the store this reads.
+
     Reuses the same recoverable-savings contract every analyzer already
-    carries (`past_overspend_usd`, #111) rather than inventing a new
-    figure, scoped to `COST_ANALYZERS` — the analyzers that actually feed the
-    cost/apply rail (`cost_proposals.py`).
+    carries (`past_overspend_usd`) rather than inventing a new figure, scoped
+    to `COST_ANALYZERS` — the analyzers that actually feed the cost/apply rail
+    (`cost_proposals.py`). The store holds every analyzer's finding, so the
+    scoping is applied here on the read rather than by restricting the scan.
 
     Reports the LARGEST single analyzer's estimate rather than a sum across
     analyzers — mirroring `largest_recoverable_usd` in `api/routes/cost.py`.
@@ -187,32 +204,33 @@ def _recoverable_teaser(db, config) -> str | None:
     would double-count and print an inflated, non-additive headline; the
     single largest entry is honest standalone because it isn't a sum of
     anything (see `_recoverable_overlap_note` in `api/routes/cost.py` for the
-    full rationale). Silent (returns None) whenever the figure wouldn't mean
-    anything: no direct DB connection (daemon holds the lock), no usage, or a
-    sub-$1 figure. Dollars are shown regardless of billing mode (product
-    decision: no differentiated messaging between subscription and API
-    users).
+    full rationale).
+
+    A COLD store renders `_COLD_TEASER`: a command to run, never a number and
+    never a zero. `$0.00 recoverable` off a scan that never ran reads as "you
+    have no waste", which is a reassurance the data does not support (root
+    anti-pattern 22). Otherwise silent (returns None) whenever the figure
+    wouldn't mean anything: no config, or a sub-$1 figure. Dollars are shown
+    regardless of billing mode (product decision: no differentiated messaging
+    between subscription and API users).
     """
-    conn = getattr(db, "conn", None)
-    if conn is None or config is None:
+    if config is None:
         return None
     try:
-        from tokenjam.core.optimize import build_report
+        from tokenjam.core.optimize import report_store
         from tokenjam.core.optimize.cost_proposals import COST_ANALYZERS
 
-        since_dt = utcnow() - timedelta(days=_TEASER_WINDOW_DAYS)
-        until_dt = utcnow()
-
-        report = build_report(
-            db=db, config=config, since=since_dt, until=until_dt,
-            findings=list(COST_ANALYZERS),
-        )
+        report = report_store.stored_report(config)
+        if report is None:
+            return _COLD_TEASER
         estimates: list[tuple[float, int]] = []
         if report.downgrade is not None:
             usd = report.downgrade.past_overspend_usd
             if usd is not None:
                 estimates.append((usd, getattr(report.downgrade, "past_overspend_tokens", None) or 0))
-        for finding in (report.findings or {}).values():
+        for name, finding in (report.findings or {}).items():
+            if name not in COST_ANALYZERS:
+                continue
             usd = getattr(finding, "past_overspend_usd", None)
             if usd is not None:
                 estimates.append((usd, getattr(finding, "past_overspend_tokens", None) or 0))


### PR DESCRIPTION
## `tj status` spent about a minute running analyzers

On a real corpus (304 agents), `tj status` took **55-59 seconds** at ~95% CPU. Compute-bound, not IO-wait.

The status table itself is cheap. The cost was the one-line recoverable-savings footer at the bottom of the screen: `_recoverable_teaser` in `tokenjam/cli/cmd_status.py` called `build_report(findings=list(COST_ANALYZERS))` **live, uncached, on every plain `tj status`**. That dispatches the whole cost analyzer set over the entire corpus, including the deliberately unbounded `relearn` scan, so the user waits a minute for a table that was ready in a second.

## This is a failure mode the codebase already documented

`tokenjam/core/optimize/report_store.py` was written to end exactly this, after the same inline scan on an HTTP request thread hung the dashboard's recoverable-waste panel and the Budget-at-risk card for minutes. Its module docstring states the rule outright:

> **no request path runs an analyzer.** Analyzer runs happen in exactly three places, all of them off the request path and all of them landing here.

A status command a user types to read a table is the same kind of path. The CLI caller had simply never adopted the store.

## The fix

`_recoverable_teaser` now reads `report_store.stored_report(config)`. Nothing else about the figure changed: it is still the largest single analyzer estimate rather than a sum (the analyzers price overlapping angles on the same spans, so summing would print an inflated non-additive headline), still gated at $1, still shown regardless of billing mode. The `COST_ANALYZERS` scoping the teaser has always claimed is now applied on the read, since the store holds every analyzer's finding rather than just the cost rail's.

Analyzer runs stay where they belong: daemon boot, the daemon's schedule, a user rescan, or an explicit `tj optimize`.

**A cold store renders no figure at all.** Not zero, not `$0.00`, not "nothing to recover". A scan that never ran cannot support an absence claim, and `$0.00 recoverable` reads as reassurance. The cold line names the command that would produce a figure and states no quantity:

```
Recoverable waste has not been scanned yet: run tj optimize.
```

The teaser no longer needs a `db` argument, which also fixes a smaller bug: it used to go silent whenever the daemon held the write lock (API-shim mode, no `.conn`), because it had no connection to scan with. That is precisely the mode where the store is warm, so the figure now renders there.

## Measured

Same machine, same corpus, same command:

| | wall | cpu |
|---|---|---|
| before | **58.4s** | 44.2s user + 11.7s system, 95% CPU |
| after | **1.6s** | 2.9s user + 0.4s system |

Both footer states, rendered from the real CLI against the same corpus:

```
# warm store
$295 / 62.1M tokens recoverable (largest single fix): run tj optimize

# cold store
Recoverable waste has not been scanned yet: run tj optimize.
```

## Tests

- `tests/unit/test_cmd_status_teaser.py` rewritten against the store rather than a monkeypatched `build_report`.
- The test that pinned the teaser's silence without a direct DB connection is **inverted, not deleted**: it now pins that the stored figure renders in that mode.
- New: cold store renders a command and no figure; the `COST_ANALYZERS` scoping cannot be bypassed by a finding stored under another name.
- New regression pin: the status module cannot reach `build_report`, asserted both statically against the source and dynamically with `build_report` trapped to raise.

`pytest tests/unit -k "status or optimize or report_store"` -> 402 passed.
`tests/unit/test_advertised_commands_are_invocable.py` -> 12 passed (the footer still advertises `tj optimize`, which resolves).

## Sweep

Every other `build_report` / `COST_ANALYZERS` / direct-analyzer call site in `tokenjam/cli/` is a command whose entire purpose is the analysis the user asked for, so none is the same defect:

- `cmd_optimize.py` - the analyzer command itself
- `cmd_report.py` - `tj report --trim` / `--reuse`, single scoped analyzer per invocation
- `cmd_route.py` - `tj route`, `findings=["downsize"]`
- `cmd_quickstart.py` - the zero-install demo whose output *is* the figure
- `data_access.py` / `cmd_quota_audit.py` - `audit_opus_quota`, reached only from `tj quota-audit`

`tj status` was the only plain command path running an analyzer as a side effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
