### PR TITLE
Add a total tile to the optimize row, and stop wide Lens tables overflowing the page

### DIFF
--- a/tests/unit/test_lens_dashboard_states.py
+++ b/tests/unit/test_lens_dashboard_states.py
@@ -445,9 +445,12 @@ def test_the_shimmer_primitive_honors_reduced_motion(html):
 # now accept as an override, defaulting to fmtCost everywhere else.
 def _fmt_dash_usd_source() -> str:
     src = _UI.read_text(encoding="utf-8")
+    start = src.index("function roundToCents(n)")
+    end = src.index("\n}\n", start) + 2
+    round_block = src[start:end]
     start = src.index("function fmtDashUsd(v)")
     end = src.index("\n}\n", start) + 2
-    return src[start:end]
+    return round_block + "\n" + src[start:end]
 
 
 def _dash_usd(v):
@@ -552,6 +555,7 @@ def _dedup_source() -> str:
 
     return "\n".join([
         block("function fmtCost(usd)"),
+        block("function roundToCents(n)"),
         block("function fmtDashUsd(v)"),
         block("function fmtTokens(n)"),
         block("function fmtFramedDollar(v, framing, dollarFmt = fmtCost)"),

--- a/tests/unit/test_lens_ui_regression.py
+++ b/tests/unit/test_lens_ui_regression.py
@@ -14,6 +14,9 @@ follow-ups: opt-in light payload, lazy per-span attributes, capped/pinned rows).
 """
 from __future__ import annotations
 
+import json
+import shutil
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -436,3 +439,172 @@ def test_cursor_listbox_scrolls_horizontally_and_truncates_paths(html: str) -> N
     ), "cur-listbox must scroll horizontally, not just vertically"
     assert '<td class="mono" title=${c.path}>${shortPath(c.path)}</td>' in html
     assert "title=${r.path + ' — review the diff'}" in html
+
+
+# --------------------------------------------------------------------------- #
+# Total opportunity tile — a 7th tile, first in the Dashboard's "Opportunities
+# to optimize token efficiency" row, summing the six per-analyzer figures.
+#
+# `totalOpportunityFigure()` is the one pure function that decides the sum and
+# its population; a static string match on the source would still pass if that
+# arithmetic or exclusion logic were wrong (the exact critique
+# test_lens_select_all_behaviour.py levels at grep-only tests), so it is
+# extracted straight out of the served index.html and run under node instead,
+# the same trick that module and test_lens_dashboard_states.py use.
+# --------------------------------------------------------------------------- #
+_node = pytest.mark.skipif(shutil.which("node") is None, reason="node not available for JS evaluation")
+
+
+def _total_figure_source() -> str:
+    src = _UI.read_text(encoding="utf-8")
+    start = src.index("function totalOpportunityFigure")
+    end = src.index("// The TOTAL tile itself", start)
+    return src[start:end]
+
+
+def _total_figure(tiles: list[dict]):
+    script = (
+        _total_figure_source()
+        + "\nconsole.log(JSON.stringify(totalOpportunityFigure(" + json.dumps(tiles) + ")));"
+    )
+    proc = subprocess.run(
+        ["node", "--input-type=module", "-e", script],
+        capture_output=True, text=True, check=True,
+    )
+    return json.loads(proc.stdout.strip())
+
+
+@_node
+def test_total_equals_the_plain_sum_of_actionable_contributors():
+    tiles = [
+        {"name": "subagent", "state": "actionable", "usd": 1528.89, "tokens": 100},
+        {"name": "resend", "state": "actionable", "usd": 374.33, "tokens": 200},
+        {"name": "downsize", "state": "actionable", "usd": 295.23, "tokens": 300},
+    ]
+    fig = _total_figure(tiles)
+    assert fig["state"] == "populated"
+    assert round(fig["totalUsd"], 2) == round(1528.89 + 374.33 + 295.23, 2)
+    assert fig["totalTokens"] == 600
+    assert fig["contributorCount"] == 3
+
+
+@_node
+def test_an_absent_no_findings_analyzer_is_excluded_not_zeroed():
+    # Deadweight with no candidates renders 'No candidates', never a $0 tile
+    # (root CLAUDE.md anti-pattern 22). Its state carries no usd at all here,
+    # mirroring classifyFinding()'s real 'no_findings' shape, and the sum must
+    # come out identical to the same row with that tile removed entirely --
+    # proof it is excluded structurally (by state), not by a falsy usd check.
+    with_deadweight = [
+        {"name": "subagent", "state": "actionable", "usd": 100.0, "tokens": 10},
+        {"name": "deadweight", "state": "no_findings"},
+    ]
+    without_deadweight = [
+        {"name": "subagent", "state": "actionable", "usd": 100.0, "tokens": 10},
+    ]
+    with_fig = _total_figure(with_deadweight)
+    without_fig = _total_figure(without_deadweight)
+    assert with_fig["totalUsd"] == without_fig["totalUsd"] == 100.0
+    assert with_fig["contributorCount"] == without_fig["contributorCount"] == 1
+    # The excluded tile is still counted as a KNOWN (resolved) tile, just not
+    # a contributor -- it answered "nothing here", which is not the same as
+    # "not yet known".
+    assert with_fig["knownCount"] == 2
+
+
+@_node
+def test_an_at_ceiling_tile_contributes_nothing_to_the_sum():
+    # cache's positive "already at the ceiling" state carries a metric string,
+    # never a usd figure; it must be excluded the same way no_findings is.
+    tiles = [
+        {"name": "subagent", "state": "actionable", "usd": 50.0, "tokens": 5},
+        {"name": "cache", "state": "at_ceiling", "metric": "98% cache efficacy"},
+    ]
+    fig = _total_figure(tiles)
+    assert fig["totalUsd"] == 50.0
+    assert fig["contributorCount"] == 1
+
+
+@_node
+def test_all_analyzers_unresolved_is_the_unknown_state_never_zero():
+    # Nothing has resolved yet -- the tile must render a skeleton, not a $0.00
+    # total (the worst possible placeholder: it reads as "no waste").
+    tiles = [
+        {"name": "subagent", "state": "not_ready", "hint": "Not run on Overview."},
+        {"name": "resend", "state": "not_ready", "hint": "Not run on Overview."},
+    ]
+    fig = _total_figure(tiles)
+    assert fig["state"] == "unknown"
+    assert fig["totalUsd"] == 0
+    assert fig["knownCount"] == 0
+
+
+@_node
+def test_every_analyzer_resolved_empty_is_the_empty_state():
+    # Every tile answered, none had a recoverable figure: this is the ONE
+    # legitimate home for empty-state copy, distinct from 'unknown'.
+    tiles = [
+        {"name": "subagent", "state": "no_findings"},
+        {"name": "deadweight", "state": "no_findings"},
+    ]
+    fig = _total_figure(tiles)
+    assert fig["state"] == "empty"
+    assert fig["totalUsd"] == 0
+    assert fig["contributorCount"] == 0
+    assert fig["knownCount"] == 2
+
+
+@_node
+def test_a_partially_resolved_row_discloses_its_coverage_not_a_full_claim():
+    # Some analyzers answered, some have not: the total must not claim to
+    # cover every tile in the row. unresolvedCount is how the renderer knows
+    # to disclose the partial population instead of publishing a total that
+    # reads as complete.
+    tiles = [
+        {"name": "subagent", "state": "actionable", "usd": 10.0, "tokens": 1},
+        {"name": "resend", "state": "not_ready", "hint": "Not run on Overview."},
+    ]
+    fig = _total_figure(tiles)
+    assert fig["state"] == "populated"
+    assert fig["totalUsd"] == 10.0
+    assert fig["unresolvedCount"] == 1
+    assert fig["totalCount"] == 2
+    assert fig["knownCount"] == 1
+
+
+def test_total_tile_is_first_in_the_row_and_visually_distinct(html: str) -> None:
+    # Rendered before tiles.map(), so it is the first child of .tile-grid; a
+    # dedicated CSS class carries the weight/border distinction (never the
+    # accent colour, which means "typeable/clickable" and this tile links
+    # nowhere).
+    assert (
+        "<${TotalOpportunityTile} tiles=${tiles} framing=${framing} />${tiles.map(t => {" in html
+    ), "the total tile must render before tiles.map() in the tile-grid"
+    assert ".rec-tile.total-tile" in html
+    assert ".rec-tile.total-tile .rec-amount { color: var(--text); }" in html
+
+
+def test_total_tile_cannot_render_a_dollar_figure_while_unresolved(html: str) -> None:
+    # The 'unknown' branch returns before any amount/hint computation touches
+    # fmtFramedSavings -- a skeleton, never a number, while nothing has
+    # resolved. Anchor on the guard clause and its skeleton markup.
+    fn = html[html.index("function TotalOpportunityTile("):]
+    fn = fn[: fn.index("\n}\n")]
+    assert "if (fig.state === 'unknown') {" in fn
+    idx_guard = fn.index("if (fig.state === 'unknown')")
+    idx_amount = fn.index("const amount")
+    assert idx_guard < idx_amount, "the unresolved guard must return before computing an amount"
+    assert 'class="rec-tile total-tile rec-skel" aria-hidden="true"' in fn
+
+
+def test_total_tile_comment_marks_the_sum_as_deliberate_and_scoped(html: str) -> None:
+    # The founder decision (naive sum now, netted rollup once `script` runs
+    # for a persona that reaches this row) must be recorded at the summing
+    # site, with no internal ticket id per root anti-pattern 11.
+    fn_start = html.index("function totalOpportunityFigure")
+    comment = html[html.index("// The TOTAL opportunity tile"): fn_start]
+    assert "PLAIN SUM" in comment
+    assert "netted cross-analyzer" in comment
+    assert "persona-disabled" in comment
+    import re
+    assert not re.search(r"#\d+", comment), "no internal ticket id in a source comment"

--- a/tests/unit/test_lens_ui_regression.py
+++ b/tests/unit/test_lens_ui_regression.py
@@ -381,3 +381,58 @@ def test_dashboard_empty_tiles_are_not_clickable(html: str) -> None:
     # cursor) so an empty tile cannot read as a dead link.
     assert ".rec-tile.static { cursor: default; }" in html
     assert ".rec-tile.static:hover { border-color: var(--border); }" in html
+
+
+# --------------------------------------------------------------------------- #
+# Lens table horizontal-overflow fix — wide .opt-table findings tables (long
+# absolute paths, provider/model strings) were pushing the whole page into
+# horizontal scroll instead of scrolling inside their own container.
+# --------------------------------------------------------------------------- #
+def test_body_never_scrolls_horizontally(html: str) -> None:
+    # Belt-and-suspenders: no descendant, however wide, may push the PAGE
+    # itself into horizontal scroll. Wide content must scroll inside its own
+    # .table-wrap instead.
+    assert "overflow-x: hidden;" in html
+    body = html[html.index("\nbody {"):]
+    body = body[: body.index("}")]
+    assert "overflow-x: hidden;" in body, "body rule must set overflow-x: hidden"
+
+
+def test_every_opt_table_is_wrapped_for_horizontal_scroll(html: str) -> None:
+    # Every OptimizeFinding detail table (.opt-table) must sit inside a
+    # .table-wrap (overflow-x: auto) container so a long unbreakable string
+    # (a repo-relative path, a provider/model id) scrolls inside the table
+    # instead of forcing the whole card, and the page, wider than the
+    # viewport. A bare, unwrapped `<table class="opt-table"` is the bug.
+    import re
+
+    for m in re.finditer(r'<table class="opt-table"', html):
+        preceding = html[max(0, m.start() - 40): m.start()]
+        assert '<div class="table-wrap">' in preceding, (
+            f"unwrapped .opt-table at offset {m.start()}: {preceding!r}"
+        )
+
+
+def test_recurring_inclusions_label_is_truncated_with_full_path_in_title(html: str) -> None:
+    # The "What's re-included" column in the resend finding's recurring-
+    # inclusions table renders absolute paths. Rendering them untruncated
+    # forced the table (and the page) wider than the viewport, with the
+    # label unreadable on both ends. shortPath() truncates to the last two
+    # path segments for display; the full path still rides in title= for a
+    # hover tooltip.
+    assert (
+        '<td class="mono" title=${r.label}>${shortPath(r.label)}</td>' in html
+    ), "recurring-inclusions label must be shortPath()-truncated with the full value in title="
+
+
+def test_cursor_listbox_scrolls_horizontally_and_truncates_paths(html: str) -> None:
+    # The Summarize/Rules file pickers (.cur-listbox > .cur-table) render a
+    # File column of absolute paths. The listbox must scroll horizontally on
+    # its own (overflow-x, alongside its existing overflow-y) instead of
+    # relying on the page to scroll, and the path itself must be
+    # shortPath()-truncated with the full path in a hover title.
+    assert (
+        ".cur-listbox { max-height:380px; overflow-y:auto; overflow-x:auto;" in html
+    ), "cur-listbox must scroll horizontally, not just vertically"
+    assert '<td class="mono" title=${c.path}>${shortPath(c.path)}</td>' in html
+    assert "title=${r.path + ' — review the diff'}" in html

--- a/tests/unit/test_lens_ui_regression.py
+++ b/tests/unit/test_lens_ui_regression.py
@@ -455,11 +455,21 @@ def test_cursor_listbox_scrolls_horizontally_and_truncates_paths(html: str) -> N
 _node = pytest.mark.skipif(shutil.which("node") is None, reason="node not available for JS evaluation")
 
 
+def _round_to_cents_source() -> str:
+    src = _UI.read_text(encoding="utf-8")
+    start = src.index("function roundToCents(n)")
+    end = src.index("\n}\n", start) + 2
+    return src[start:end]
+
+
 def _total_figure_source() -> str:
     src = _UI.read_text(encoding="utf-8")
     start = src.index("function totalOpportunityFigure")
     end = src.index("// The TOTAL tile itself", start)
-    return src[start:end]
+    # totalOpportunityFigure calls roundToCents (the same helper fmtDashUsd
+    # uses) to round each contributor before summing -- pull it in too so
+    # this extraction doesn't drift from the real dependency.
+    return _round_to_cents_source() + "\n" + src[start:end]
 
 
 def _total_figure(tiles: list[dict]):
@@ -486,6 +496,28 @@ def test_total_equals_the_plain_sum_of_actionable_contributors():
     assert round(fig["totalUsd"], 2) == round(1528.89 + 374.33 + 295.23, 2)
     assert fig["totalTokens"] == 600
     assert fig["contributorCount"] == 3
+
+
+@_node
+def test_total_reconciles_with_the_sum_of_the_displayed_per_tile_figures():
+    # The total must equal what you get from adding the SIX RENDERED figures
+    # by hand, not a sum of raw values rounded once at the end -- those two
+    # differ whenever contributors' raw cents round independently. Fixture
+    # chosen so the two strategies disagree by a whole cent, unaffected by
+    # any binary floating-point boundary ambiguity (verified directly: raw
+    # sum 3.012 rounds once to 3.01, but each 1.004 individually rounds down
+    # to 1.00, so the sum of the three DISPLAYED figures is 3.00).
+    tiles = [
+        {"name": "subagent", "state": "actionable", "usd": 1.004, "tokens": 1},
+        {"name": "resend", "state": "actionable", "usd": 1.004, "tokens": 1},
+        {"name": "downsize", "state": "actionable", "usd": 1.004, "tokens": 1},
+    ]
+    fig = _total_figure(tiles)
+    # The sum of the values AS DISPLAYED (each tile renders $1.00 via
+    # fmtDashUsd's 2dp rounding) is $3.00 -- not the sum-then-round-once
+    # figure of $3.01 a naive raw sum would produce.
+    assert fig["totalUsd"] == 3.00
+    assert fig["totalUsd"] != round(1.004 + 1.004 + 1.004, 2)  # != 3.01
 
 
 @_node
@@ -608,3 +640,45 @@ def test_total_tile_comment_marks_the_sum_as_deliberate_and_scoped(html: str) ->
     assert "persona-disabled" in comment
     import re
     assert not re.search(r"#\d+", comment), "no internal ticket id in a source comment"
+
+
+def test_total_matches_the_displayed_per_tile_sum(html: str) -> None:
+    # roundToCents backs fmtDashUsd's own rounding (a tile's displayed
+    # figure) AND totalOpportunityFigure's summing step, from the same
+    # helper -- never two independent rounding expressions that could drift
+    # apart. Anchors both call sites plus the shared helper's definition.
+    assert "function roundToCents(n) {" in html
+    assert "return '$' + roundToCents(n).toLocaleString(" in html  # fmtDashUsd
+    assert (
+        "const totalUsd = roundToCents(contributors.reduce((sum, t) => sum + roundToCents(t.usd), 0));"
+        in html
+    )
+
+
+def test_opportunities_row_fits_seven_tiles_without_widening_the_shared_compact_grid(html: str) -> None:
+    # The Total tile makes this a 7-tile row (was 6), which orphaned the 7th
+    # (Deadweight) onto its own row at the shared .tile-grid.compact minmax.
+    # .opp-grid narrows just this row's minmax so all seven fit across at
+    # the normal content width; it must NOT touch the shared .compact rule
+    # (the health-glance row and this row's own loading skeleton also use
+    # it, and don't need narrowing), and both the answered-tiles grid and
+    # its loading skeleton must carry the class so neither reflows against
+    # the other when the real data lands.
+    assert ".tile-grid.compact.opp-grid { grid-template-columns: repeat(auto-fill, minmax(128px, 1fr)); }" in html
+    assert '.tile-grid.compact { grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));' in html
+    assert 'class="tile-grid compact opp-grid"' in html
+    # Both call sites carry it: the scanning skeleton and the answered tiles.
+    assert html.count('class="tile-grid compact opp-grid"') == 2
+    # The health-glance row is a separate grid and must NOT be narrowed.
+    health = html[html.index('<div class="band-label">Health at a glance</div>'):]
+    health = health[: health.index("<!-- The HERO")]
+    assert 'class="tile-grid compact"' in health
+    assert "opp-grid" not in health
+
+
+def test_skeleton_tile_count_matches_the_seven_real_tiles(html: str) -> None:
+    # REC_SKELETON_TILES stood in for the row before the Total tile existed
+    # (6 placeholders for 6 real tiles). Left at 6 it would render one fewer
+    # skeleton box than the 7 real tiles that land, a visible reflow.
+    assert "const REC_SKELETON_TILES = [0, 1, 2, 3, 4, 5, 6];" in html
+    assert "const REC_SKELETON_TILES = [0, 1, 2, 3, 4, 5];" not in html

--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -1182,6 +1182,15 @@ a.rec-tile:hover .rec-go { color: var(--accent); transform: translateX(2px); }
   font-size: 11px; color: var(--text-faint); line-height: 1.4;
   display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;
 }
+/* TOTAL tile: first in the row, set apart from its six siblings by weight
+   and border rather than the accent colour. It links nowhere (no single
+   detail page a cross-analyzer sum could open), and accent means
+   "typeable/clickable" everywhere else in this app, so its figure renders
+   in plain text instead. */
+.rec-tile.total-tile { border-width: 2px; background: var(--surface2); }
+.rec-tile.total-tile .rec-name { font-weight: 700; }
+.rec-tile.total-tile .rec-amount { color: var(--text); }
+.tile-grid.compact .rec-tile.total-tile .rec-amount { font-size: 17px; }
 .estimated-tag {
   font-family: 'Geist Mono', monospace; font-size: 9px; text-transform: uppercase;
   letter-spacing: 0.04em; color: var(--warn); border: 1px solid var(--warn);
@@ -8019,6 +8028,73 @@ function recoverableTiles(opt) {
   return rankTiles(out, opt.finding_rank);
 }
 
+// The TOTAL opportunity tile's figure: a deliberate PLAIN SUM of the
+// per-analyzer actionable figures in `tiles`, NOT the netted cross-analyzer
+// rollup that already exists elsewhere in core/optimize and is the more
+// defensible number when two analyzers can claim the same tokens. Founder
+// decision: the MVP audience is SDK/Claude-Code users, and the one analyzer
+// whose claims can overlap another's (`script`) is persona-disabled for
+// them, so the overlapping-claim double-count the netted rollup guards
+// against is not in play for the shipped persona today. This naive sum is
+// scoped to that persona; swap it for the netted rollup once a persona that
+// runs `script` reaches this row, not before.
+//
+// A tile with no candidates (state 'no_findings' / 'at_ceiling') is ABSENT
+// from the sum, never a zero contribution — it is excluded by its `state`,
+// not by testing its `usd` value, so it can't silently coerce into a zero
+// that looks like a measured "nothing here". A tile that has not resolved
+// yet (`not_ready`) is likewise excluded, and its presence is surfaced via
+// `unresolvedCount` so a caller can disclose that the total does not yet
+// cover every analyzer in the row rather than publishing a total that reads
+// as complete.
+function totalOpportunityFigure(tiles) {
+  const known = tiles.filter(t => t.state !== 'not_ready');
+  const contributors = known.filter(t => t.state === 'actionable' && t.usd != null);
+  const totalUsd = contributors.reduce((sum, t) => sum + t.usd, 0);
+  const totalTokens = contributors.reduce((sum, t) => sum + (t.tokens || 0), 0);
+  return {
+    // 'unknown': nothing in the row has resolved yet — render a skeleton,
+    //   never a number (a zero here would read as "no waste").
+    // 'empty': every resolved analyzer reported nothing to recover.
+    // 'populated': at least one resolved analyzer contributed a real amount.
+    state: known.length === 0 ? 'unknown' : (contributors.length === 0 ? 'empty' : 'populated'),
+    totalUsd, totalTokens,
+    contributorCount: contributors.length,
+    knownCount: known.length,
+    totalCount: tiles.length,
+    unresolvedCount: tiles.length - known.length,
+  };
+}
+
+// The TOTAL tile itself: first in the row, visually distinct from its six
+// siblings via weight and border rather than the accent colour — this tile
+// links nowhere (no single detail page sums to), and accent means
+// "typeable/clickable" everywhere else in this app.
+function TotalOpportunityTile({ tiles, framing }) {
+  const fig = totalOpportunityFigure(tiles);
+  if (fig.state === 'unknown') {
+    return html`<div class="rec-tile total-tile rec-skel" aria-hidden="true">
+      <div class="shimmer" style="height:12px;width:60%"></div>
+      <div class="shimmer" style="height:18px;width:70%;margin-top:8px"></div>
+      <div class="shimmer" style="height:10px;width:100%;margin-top:8px"></div>
+    </div>`;
+  }
+  const amount = fig.state === 'empty'
+    ? 'No recoverable total yet.'
+    : fmtFramedSavings(fig.totalUsd, fig.totalTokens, framing, fmtDashUsd);
+  const hint = fig.state === 'empty'
+    ? 'Every resolved analyzer below reported nothing to recover.'
+    : (fig.unresolvedCount > 0
+        ? `Sum of ${fig.contributorCount} of ${fig.totalCount} analyzers: ${fig.unresolvedCount} still resolving.`
+        : `Sum across ${fig.contributorCount} of ${fig.totalCount} analyzers with a recoverable figure this window.`);
+  const amtCls = 'rec-amount' + (fig.state === 'empty' ? ' dim' : '');
+  return html`<div class="rec-tile total-tile static">
+    <div class="rec-name">Total opportunity</div>
+    <div class=${amtCls}>${amount}</div>
+    <div class="rec-hint">${hint}</div>
+  </div>`;
+}
+
 // The analyzers that earn their OWN Optimize detail sub-page (#/optimize/<name>)
 // and a left-submenu entry: exactly the tiles that carry a real finding
 // (`state === 'actionable'`), in the same biggest-waste-first order the tiles
@@ -13283,7 +13359,7 @@ function DashboardView({ params, persona }) {
                 ${bandState === 'tiles' || bandState === 'none' || bandState === 'stale' ? html`
                 <div class="tile-grid compact">
                   ${tiles.length === 0 ? html`<div class="empty">No overspend found.</div>`
-                    : tiles.map(t => {
+                    : html`<${TotalOpportunityTile} tiles=${tiles} framing=${framing} />${tiles.map(t => {
                       const meta = ANALYZER_META[t.name] || { title: capitalize(t.name), hint: '' };
                       // ONLY a tile with a real finding is clickable (Option B,
                       // founder-approved): it routes straight to that analyzer's
@@ -13314,7 +13390,7 @@ function DashboardView({ params, persona }) {
                       return hasPage
                         ? html`<a class=${cls} href=${href}>${inner}<span class="rec-go" aria-hidden="true">→</span></a>`
                         : html`<div class=${cls}>${inner}</div>`;
-                    })}
+                    })}`}
                 </div>` : null}
               </div>
               <div class="dash-col health-glance">

--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -1156,6 +1156,16 @@ a.rec-tile.ok:hover { border-color: var(--success); }
 .tile-grid.compact .rec-amount { font-size: 15px; }
 .tile-grid.compact .rec-hint { font-size: 10px; }
 .tile-grid.compact .health-tile { padding: 8px 10px; }
+/* The opportunities row only (Total + six breakdown tiles = 7): a narrower
+   minmax than the shared .compact default so all seven fit across at the
+   normal content width instead of the 7th (Deadweight) orphaning onto a
+   second row, detaching the Total tile from what it sums. Scoped to this
+   row via .opp-grid rather than lowering .tile-grid.compact's own minmax,
+   which the health-glance row (5 tiles) and this row's own loading skeleton
+   also use and don't need narrowed. auto-fill still wraps to a second row
+   below this width, same as any other tile-grid -- narrower viewports keep
+   degrading normally rather than forcing a squashed single row. */
+.tile-grid.compact.opp-grid { grid-template-columns: repeat(auto-fill, minmax(128px, 1fr)); }
 .rec-tile {
   display: block; text-decoration: none; color: inherit; position: relative;
   background: var(--surface); border: 1px solid var(--border); border-radius: 8px;
@@ -2247,6 +2257,14 @@ function fmtCost(usd) {
   if (usd === 0) return '$0.0000';
   return usd < 0.001 ? '$' + usd.toFixed(6) : '$' + usd.toFixed(4);
 }
+// The ONE rounding rule behind every Dashboard dollar figure's displayed
+// precision, so a caller that needs to reconcile a computed figure (e.g. the
+// Total opportunity tile summing several already-rounded tile figures) can
+// round to the exact same cent fmtDashUsd would show, instead of keeping a
+// second rounding expression that could drift from it.
+function roundToCents(n) {
+  return Math.round(n * 100) / 100;
+}
 // Dashboard-only currency formatter: at most 2 decimal places (product
 // decision, "use just two decimals at most throughout dashboard"), with
 // thousands grouping for readability -- the same 2dp convention fmtUsd
@@ -2259,7 +2277,7 @@ function fmtCost(usd) {
 function fmtDashUsd(v) {
   const n = Number(v || 0);
   if (n > 0 && n < 0.01) return '< $0.01';
-  return '$' + n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+  return '$' + roundToCents(n).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
 }
 function fmtTokens(n) {
   if (n == null) return '-';
@@ -8050,7 +8068,14 @@ function recoverableTiles(opt) {
 function totalOpportunityFigure(tiles) {
   const known = tiles.filter(t => t.state !== 'not_ready');
   const contributors = known.filter(t => t.state === 'actionable' && t.usd != null);
-  const totalUsd = contributors.reduce((sum, t) => sum + t.usd, 0);
+  // Reconciliation: the total must equal the sum of the figures AS DISPLAYED
+  // on the six breakdown tiles, not a sum of raw values rounded once at the
+  // end -- those two disagree whenever more than one contributor's raw cents
+  // round independently. Round each contributor with roundToCents (the same
+  // helper fmtDashUsd uses to format a tile's own figure, so this can never
+  // drift from what a tile actually shows) BEFORE summing, then round the
+  // sum itself once more to clear any float drift the additions reintroduce.
+  const totalUsd = roundToCents(contributors.reduce((sum, t) => sum + roundToCents(t.usd), 0));
   const totalTokens = contributors.reduce((sum, t) => sum + (t.tokens || 0), 0);
   return {
     // 'unknown': nothing in the row has resolved yet — render a skeleton,
@@ -12814,7 +12839,10 @@ const OPTIMIZE_WAIT_MIN = Math.round(OPTIMIZE_WAIT_MS / 60000);
 // analyzers with no fix for it (measured: resend, summarize, downsize,
 // deadweight, subagent, relearn), so the grid keeps the same row count from the
 // placeholder through to the answer.
-const REC_SKELETON_TILES = [0, 1, 2, 3, 4, 5];
+// 7 placeholders, matching the 7 real tiles (the Total tile plus the six
+// breakdown analyzers) so the skeleton's width and row-count match what
+// lands, and the row doesn't reflow when the real data arrives.
+const REC_SKELETON_TILES = [0, 1, 2, 3, 4, 5, 6];
 
 // Candidate windows, ascending, for every screen with a window selector. Only
 // entries whose day count fits within the store's actually-available data
@@ -13317,7 +13345,7 @@ function DashboardView({ params, persona }) {
                       to say there is nothing recoverable is 'none', which
                       requires a completed response. */ ''}
                 ${bandState === 'scanning' ? html`
-                  <div class="tile-grid compact">
+                  <div class="tile-grid compact opp-grid">
                     ${/* Mirrors the answered tile below: name line, amount line,
                           two clamped hint lines, inside the real .rec-tile box.
                           Same bar-height-tracks-font-size convention the Review
@@ -13357,7 +13385,7 @@ function DashboardView({ params, persona }) {
                     <span class="sz-link" onClick=${retryOptimize}>${optState.phase === 'timeout' ? 'keep waiting' : 'try again'}</span>
                   </div>` : null}
                 ${bandState === 'tiles' || bandState === 'none' || bandState === 'stale' ? html`
-                <div class="tile-grid compact">
+                <div class="tile-grid compact opp-grid">
                   ${tiles.length === 0 ? html`<div class="empty">No overspend found.</div>`
                     : html`<${TotalOpportunityTile} tiles=${tiles} framing=${framing} />${tiles.map(t => {
                       const meta = ANALYZER_META[t.name] || { title: capitalize(t.name), hint: '' };

--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -118,6 +118,11 @@ body {
   color: var(--text);
   display: flex;
   min-height: 100vh;
+  /* Belt-and-suspenders: no descendant (a table with an unbreakable
+     string, an unwrapped .opt-table, ...) may ever push the page itself
+     into horizontal scroll. Wide content scrolls inside its own
+     .table-wrap; the body never does. */
+  overflow-x: hidden;
 }
 code, .mono {
   font-family: 'Geist Mono', monospace;
@@ -1993,7 +1998,7 @@ code.md-code {
 .cur-mrow .rm:hover { border-color:var(--error); }
 .cur-cwd { font-size:12px; color:var(--text-faint); margin:0 2px; line-height:1.5; }
 .cur-cwd code { color:var(--text-dim); }
-.cur-listbox { max-height:380px; overflow-y:auto; border:1px solid var(--border); border-radius:9px; background:var(--surface); }
+.cur-listbox { max-height:380px; overflow-y:auto; overflow-x:auto; border:1px solid var(--border); border-radius:9px; background:var(--surface); }
 /* The last row's divider would otherwise double up against the box border. */
 .cur-listbox > .sz-runrow:last-child { border-bottom:none; }
 .rev-note { margin:0; }
@@ -7080,7 +7085,7 @@ function DriftView({ params }) {
           <div style="font-size:12px;color:var(--text-dim);margin-bottom:12px;font-family:'Geist Mono',monospace">
             Baseline: ${a.baseline.sessions_sampled} sessions sampled${a.baseline.computed_at ? ', computed ' + fmtAgo(a.baseline.computed_at) : ''}
           </div>
-          <table>
+          <div class="table-wrap"><table>
             <thead><tr><th>Metric</th><th>Baseline</th><th>Latest</th><th>Z-score (threshold: 2.0\u03C3)</th><th></th></tr></thead>
             <tbody>
               ${metrics.map(([label, avgKey, stdKey, latestKey]) => {
@@ -7119,7 +7124,7 @@ function DriftView({ params }) {
                 `;
               })}
             </tbody>
-          </table>
+          </table></div>
         `}
       </div>
     `)}
@@ -8242,7 +8247,7 @@ function OptimizeFinding({ name, opt, framing, proposals, onProposalChanged, onP
       <div class="opt-line">${dg.percent_of_sessions}% of sessions match a smaller-model candidate shape (${dg.candidate_sessions} of ${dg.total_sessions}).</div>
       ${dg.suggestions && Object.keys(dg.suggestions).length ? html`<div class="opt-line dim">Pattern: ${Object.entries(dg.suggestions).map(([k, v]) => k + ' → ' + v).join(', ')}</div>` : null}
       ${(dg.examples || []).length ? html`<div class="opt-sub">Examples</div>
-        <table class="opt-table"><tbody>${dg.examples.map(ex => html`<tr><td class="mono">${(ex.trace_id || '').slice(0, 8)}…</td><td>${ex.tool_calls} tools</td><td class="mono">${ex.model}</td></tr>`)}</tbody></table>` : null}
+        <div class="table-wrap"><table class="opt-table"><tbody>${dg.examples.map(ex => html`<tr><td class="mono">${(ex.trace_id || '').slice(0, 8)}…</td><td>${ex.tool_calls} tools</td><td class="mono">${ex.model}</td></tr>`)}</tbody></table></div>` : null}
       ${dg.caveat ? html`<div class="opt-caveat">! ${dg.caveat}</div>` : null}`;
   } else if (name === 'placement') {
     // Batch API placement: unattended, cadence-regular workloads whose spend
@@ -8279,8 +8284,8 @@ function OptimizeFinding({ name, opt, framing, proposals, onProposalChanged, onP
     const isApi = framing && framing.pricing_mode === 'api';
     body = html`
       <div class="opt-line">${n} workload${n !== 1 ? 's' : ''} fit the batch shape <span class="dim">(regular cadence, no human turn after the first model call)</span>: <b>${fd.percent_of_window_cost}%</b> of window cost.</div>
-      <table class="opt-table"><thead><tr><th>Agent</th><th>Cadence</th><th>Tokens</th>${isApi ? html`<th>Spend → batch rate</th>` : null}</tr></thead>
-        <tbody>${fd.candidates.slice(0, 10).map(c => html`<tr><td class="mono">${c.agent_id}</td><td>${c.sessions} session${c.sessions !== 1 ? 's' : ''} every ${fmtCadence(c.median_gap_seconds)}</td><td>${fmtTokens(c.tokens)}</td>${isApi ? html`<td class="mono">${fmtCost(c.cost_usd)} → <span style="color:var(--success)">${fmtCost(c.cost_usd - c.estimated_batch_saving_usd)}</span></td>` : null}</tr>`)}</tbody></table>
+      <div class="table-wrap"><table class="opt-table"><thead><tr><th>Agent</th><th>Cadence</th><th>Tokens</th>${isApi ? html`<th>Spend → batch rate</th>` : null}</tr></thead>
+        <tbody>${fd.candidates.slice(0, 10).map(c => html`<tr><td class="mono">${c.agent_id}</td><td>${c.sessions} session${c.sessions !== 1 ? 's' : ''} every ${fmtCadence(c.median_gap_seconds)}</td><td>${fmtTokens(c.tokens)}</td>${isApi ? html`<td class="mono">${fmtCost(c.cost_usd)} → <span style="color:var(--success)">${fmtCost(c.cost_usd - c.estimated_batch_saving_usd)}</span></td>` : null}</tr>`)}</tbody></table></div>
       ${fd.candidates.length > 10 ? html`<div class="opt-line dim">…and ${fd.candidates.length - 10} more.</div>` : null}
       ${isApi && fd.past_overspend_usd != null ? html`
         <div class="opt-line" style="margin-top:8px"><span style="color:var(--success)">~${fmtCost(fd.past_overspend_usd)}</span> estimated price difference over this window <span class="price-diff-tag" title=${fd.estimate_basis}>price difference</span> <span class="dim">(the same work, billed at the Batch API's flat rate)</span></div>`
@@ -8292,8 +8297,8 @@ function OptimizeFinding({ name, opt, framing, proposals, onProposalChanged, onP
     if (name === 'cache') {
       body = html`
         ${(fd.flagged || []).length ? html`<div class="opt-line">${fd.flagged.length} (provider, model) row(s) below the efficacy threshold.</div>` : null}
-        <table class="opt-table"><thead><tr><th>Provider/Model</th><th>Efficacy</th><th>Input</th><th>Cache</th></tr></thead>
-          <tbody>${(fd.rows || []).map(r => html`<tr class=${r.flagged ? 'flagged' : ''}><td class="mono">${r.provider}/${r.model}</td><td>${(r.efficacy * 100).toFixed(0)}%</td><td>${fmtTokens(r.input_tokens)}</td><td>${fmtTokens(r.cache_tokens)}</td></tr>`)}</tbody></table>`;
+        <div class="table-wrap"><table class="opt-table"><thead><tr><th>Provider/Model</th><th>Efficacy</th><th>Input</th><th>Cache</th></tr></thead>
+          <tbody>${(fd.rows || []).map(r => html`<tr class=${r.flagged ? 'flagged' : ''}><td class="mono">${r.provider}/${r.model}</td><td>${(r.efficacy * 100).toFixed(0)}%</td><td>${fmtTokens(r.input_tokens)}</td><td>${fmtTokens(r.cache_tokens)}</td></tr>`)}</tbody></table></div>`;
     } else if (name === 'resend') {
       // Structural context re-send: how much of each turn's prompt was
       // already sent in a previous turn. Cross-persona (Claude Code + SDK
@@ -8308,11 +8313,11 @@ function OptimizeFinding({ name, opt, framing, proposals, onProposalChanged, onP
         <div class="opt-line">${(fd.repeat_share * 100).toFixed(1)}% of prompt tokens in this window were already sent in an earlier turn of the same session <span class="dim">(token-weighted aggregate, ${fd.sessions_examined} session${fd.sessions_examined !== 1 ? 's' : ''} · ${fd.turns_examined} turns)</span>.</div>
         ${median != null ? html`<div class="opt-line dim">Median session: ${(median * 100).toFixed(0)}%${p90 != null ? `, p90: ${(p90 * 100).toFixed(0)}%` : ''}. The aggregate above is token-weighted, so a handful of very long sessions can pull it well above what a typical session carries.</div>` : null}
         ${(fd.examples || []).length ? html`<div class="opt-sub">Heaviest sessions</div>
-          <table class="opt-table"><thead><tr><th>Session</th><th>Turns</th><th>Repeat share</th><th>Repeat tokens</th><th>Provider/Model</th></tr></thead>
-            <tbody>${fd.examples.map((ex, i) => html`<tr key=${i}><td class="mono">${(ex.session_id || '').slice(0, 12)}</td><td>${ex.turns}</td><td>${(ex.repeat_share * 100).toFixed(0)}%</td><td>${fmtTokens(ex.repeat_tokens)}</td><td class="mono">${ex.provider}/${ex.model}</td></tr>`)}</tbody></table>` : null}
+          <div class="table-wrap"><table class="opt-table"><thead><tr><th>Session</th><th>Turns</th><th>Repeat share</th><th>Repeat tokens</th><th>Provider/Model</th></tr></thead>
+            <tbody>${fd.examples.map((ex, i) => html`<tr key=${i}><td class="mono">${(ex.session_id || '').slice(0, 12)}</td><td>${ex.turns}</td><td>${(ex.repeat_share * 100).toFixed(0)}%</td><td>${fmtTokens(ex.repeat_tokens)}</td><td class="mono">${ex.provider}/${ex.model}</td></tr>`)}</tbody></table></div>` : null}
         ${(fd.recurring_examples || []).length ? html`<div class="opt-sub">Why: recurring inclusions</div>
-          <table class="opt-table"><thead><tr><th>What's re-included</th><th>Sessions</th><th>Occurrences</th><th>Fix</th></tr></thead>
-            <tbody>${fd.recurring_examples.slice(0, 8).map((r, i) => html`<tr key=${i}><td class="mono">${r.label}</td><td>${r.sessions}</td><td>${r.occurrences}</td><td class="dim">${r.fix}</td></tr>`)}</tbody></table>`
+          <div class="table-wrap"><table class="opt-table"><thead><tr><th>What's re-included</th><th>Sessions</th><th>Occurrences</th><th>Fix</th></tr></thead>
+            <tbody>${fd.recurring_examples.slice(0, 8).map((r, i) => html`<tr key=${i}><td class="mono" title=${r.label}>${shortPath(r.label)}</td><td>${r.sessions}</td><td>${r.occurrences}</td><td class="dim">${r.fix}</td></tr>`)}</tbody></table></div>`
           : (fd.notes && fd.notes[0] ? html`<div class="opt-line dim">${fd.notes[0]}</div>` : null)}
         <div class="opt-sub">Fixes</div>
         <div class="opt-line">${fd.fix_compaction} <span class="dim">(agent-harness users, e.g. Claude Code)</span></div>
@@ -8335,13 +8340,13 @@ function OptimizeFinding({ name, opt, framing, proposals, onProposalChanged, onP
       const skippedProvider = fd.skipped_provider_count || 0;
       body = !fd.enabled ? html`<div class="opt-line dim">${fd.hint || 'Disabled. Set [capture] prompts = true to run this analyzer.'}</div>`
         : (fd.candidates || []).length ? html`<div class="opt-line">${fd.candidates.length} prefix candidate(s) for cache_control:</div>
-          <table class="opt-table"><tbody>${fd.candidates.map(c => html`<tr><td class="mono">${(c.prefix_hash || '').slice(0, 8)}…</td><td>${c.occurrences}× shared</td><td>~${fmtTokens(c.estimated_cacheable_tokens)} cacheable</td></tr>`)}</tbody></table>`
+          <div class="table-wrap"><table class="opt-table"><tbody>${fd.candidates.map(c => html`<tr><td class="mono">${(c.prefix_hash || '').slice(0, 8)}…</td><td>${c.occurrences}× shared</td><td>~${fmtTokens(c.estimated_cacheable_tokens)} cacheable</td></tr>`)}</tbody></table></div>`
         : html`<div class="opt-line dim">No stable prefixes shared across ≥3 Anthropic calls.${skippedProvider ? ` ${skippedProvider} call(s) on a non-Anthropic provider were excluded from this analysis: this analyzer only looks at Anthropic calls today.` : ''}</div>`;
     } else if (name === 'script') {
       body = (fd.clusters || []).length ? html`
         <div class="opt-line">${fd.clusters.length} deterministic-pattern cluster(s).</div>
-        <table class="opt-table"><thead><tr><th>Instances</th><th>Signature</th><th>Avg cost</th></tr></thead>
-          <tbody>${fd.clusters.map(c => html`<tr><td>${c.instances}×</td><td class="mono">${(c.signature || []).map(s => s.tool).join(' → ').slice(0, 60)}</td><td>${fmtPerItemCost(c.avg_cost_usd, c.avg_tokens, framing)}</td></tr>`)}</tbody></table>
+        <div class="table-wrap"><table class="opt-table"><thead><tr><th>Instances</th><th>Signature</th><th>Avg cost</th></tr></thead>
+          <tbody>${fd.clusters.map(c => html`<tr><td>${c.instances}×</td><td class="mono">${(c.signature || []).map(s => s.tool).join(' → ').slice(0, 60)}</td><td>${fmtPerItemCost(c.avg_cost_usd, c.avg_tokens, framing)}</td></tr>`)}</tbody></table></div>
         ${fd.caveat ? html`<div class="opt-caveat">! ${fd.caveat}</div>` : null}`
         : html`<div class="opt-line dim">No clusters above threshold (≥20 identical signatures).</div>`;
     } else if (name === 'trim') {
@@ -8374,8 +8379,8 @@ function OptimizeFinding({ name, opt, framing, proposals, onProposalChanged, onP
       body = (fd.clusters || []).length ? html`
         <div class="opt-line">${fd.clusters.length} cluster${fd.clusters.length !== 1 ? 's' : ''} of repeated planning detected${captureModeNote(fd.capture_mode)}.</div>
         ${isDegradedCapture(fd.capture_mode) && fd.hint ? html`<div class="opt-line dim">${fd.hint}</div>` : null}
-        <table class="opt-table"><thead><tr><th>Repeats</th><th>Signature</th><th>Reuse</th><th>Script</th></tr></thead>
-          <tbody>${fd.clusters.slice(0, 5).map(c => html`<tr><td>${c.repetitions}×</td><td class="mono">${(c.tool_signature || []).join(' → ').slice(0, 60)}</td><td>${fmtFramedSavings(c.cache_reuse_recoverable_usd, c.cache_reuse_recoverable_tokens, framing)}</td><td>${fmtFramedSavings(c.script_replacement_recoverable_usd, c.script_replacement_recoverable_tokens, framing)}</td></tr>`)}</tbody></table>
+        <div class="table-wrap"><table class="opt-table"><thead><tr><th>Repeats</th><th>Signature</th><th>Reuse</th><th>Script</th></tr></thead>
+          <tbody>${fd.clusters.slice(0, 5).map(c => html`<tr><td>${c.repetitions}×</td><td class="mono">${(c.tool_signature || []).join(' → ').slice(0, 60)}</td><td>${fmtFramedSavings(c.cache_reuse_recoverable_usd, c.cache_reuse_recoverable_tokens, framing)}</td><td>${fmtFramedSavings(c.script_replacement_recoverable_usd, c.script_replacement_recoverable_tokens, framing)}</td></tr>`)}</tbody></table></div>
         ${fd.clusters[0].caveat ? html`<div class="opt-caveat">! ${fd.clusters[0].caveat}</div>` : null}`
         : html`<div class="opt-line dim">No repeated planning detected above threshold (≥3 sessions sharing a skeleton).</div>
           ${fd.hint ? html`<div class="opt-line dim">${fd.hint}</div>` : null}`;
@@ -8383,16 +8388,16 @@ function OptimizeFinding({ name, opt, framing, proposals, onProposalChanged, onP
       body = fd.total_subagents ? html`
         <div class="opt-line">${fd.total_subagents} subagent${fd.total_subagents !== 1 ? 's' : ''} across ${fd.sessions_with_subagents} session${fd.sessions_with_subagents !== 1 ? 's' : ''}, ${(fd.percent_of_cost * 100).toFixed(0)}% of window cost (${fmtFramedSavings(fd.subagent_cost_usd, fd.subagent_tokens, framing)}).</div>
         ${(fd.flagged || []).length ? html`
-          <table class="opt-table"><thead><tr><th>Session/Sub-agent</th><th>Model</th><th>Tools</th><th>Flags</th></tr></thead>
-            <tbody>${fd.flagged.slice(0, 10).map(r => html`<tr><td class="mono">${(r.session_id || '').slice(0, 8)}…/${(r.sub_agent_id || '').slice(0, 10)}</td><td class="mono">${r.model}</td><td>${r.tool_calls}</td><td>${(r.flags || []).join(', ')}</td></tr>`)}</tbody></table>`
+          <div class="table-wrap"><table class="opt-table"><thead><tr><th>Session/Sub-agent</th><th>Model</th><th>Tools</th><th>Flags</th></tr></thead>
+            <tbody>${fd.flagged.slice(0, 10).map(r => html`<tr><td class="mono">${(r.session_id || '').slice(0, 8)}…/${(r.sub_agent_id || '').slice(0, 10)}</td><td class="mono">${r.model}</td><td>${r.tool_calls}</td><td>${(r.flags || []).join(', ')}</td></tr>`)}</tbody></table></div>`
           : html`<div class="opt-line dim">No right-sizing candidates above thresholds.</div>`}
         ${fd.caveat ? html`<div class="opt-caveat">! ${fd.caveat}</div>` : null}`
         : html`<div class="opt-line dim">No subagent (Task-tool) activity in this window.</div>`;
     } else if (name === 'verbosity') {
       body = (fd.candidates || []).length ? html`
         <div class="opt-line">${fd.total_candidates || fd.candidates.length} high-verbosity candidate${(fd.total_candidates || fd.candidates.length) !== 1 ? 's' : ''} <span class="dim">(output well above the per-task-shape median)</span>.</div>
-        <table class="opt-table"><thead><tr><th>Session</th><th>Output</th><th>vs baseline</th><th>Recoverable</th></tr></thead>
-          <tbody>${fd.candidates.map(c => html`<tr><td class="mono">${(c.session_id || '').slice(0, 8)}…</td><td>${fmtTokens(c.output_tokens)}</td><td>${fmtTokens(c.baseline_output_tokens)} median, ${c.over_baseline_multiple}×</td><td>${fmtFramedSavings(c.recoverable_usd, c.over_baseline_tokens, framing)}</td></tr>`)}</tbody></table>
+        <div class="table-wrap"><table class="opt-table"><thead><tr><th>Session</th><th>Output</th><th>vs baseline</th><th>Recoverable</th></tr></thead>
+          <tbody>${fd.candidates.map(c => html`<tr><td class="mono">${(c.session_id || '').slice(0, 8)}…</td><td>${fmtTokens(c.output_tokens)}</td><td>${fmtTokens(c.baseline_output_tokens)} median, ${c.over_baseline_multiple}×</td><td>${fmtFramedSavings(c.recoverable_usd, c.over_baseline_tokens, framing)}</td></tr>`)}</tbody></table></div>
         ${fd.suggested_max_tokens ? html`<div class="opt-line dim">Remedy to review (not applied): a terse system-prompt line and/or a max_tokens cap near ~${fmtTokens(fd.suggested_max_tokens)}.</div>` : null}
         ${fd.caveat ? html`<div class="opt-caveat">! ${fd.caveat}</div>` : null}`
         : html`<div class="opt-line dim">${fd.sessions_examined === 0 ? 'No LLM spans in this window.' : `Examined ${fd.sessions_examined} session${fd.sessions_examined !== 1 ? 's' : ''} across ${fd.cohorts_examined} task-shape cohort${fd.cohorts_examined !== 1 ? 's' : ''}; no session's output ran high enough vs its cohort median to flag.`}</div>`;
@@ -8402,8 +8407,8 @@ function OptimizeFinding({ name, opt, framing, proposals, onProposalChanged, onP
         : !(fd.dead_servers || []).length ? html`<div class="opt-line dim">${(fd.notes && fd.notes.length) ? fd.notes.join(' ') : `All ${fd.configured_servers} configured MCP server${fd.configured_servers !== 1 ? 's' : ''} were invoked at least once in this window.`}</div>`
         : html`
           <div class="opt-line">${fd.dead_servers.length} dead MCP server${fd.dead_servers.length !== 1 ? 's' : ''} of ${fd.configured_servers} configured <span class="dim">(schemas injected every session, never called)</span>.</div>
-          <table class="opt-table"><thead><tr><th>Server</th><th>Sessions</th><th>Invocations</th><th>Tax (window)</th></tr></thead>
-            <tbody>${fd.dead_servers.map(s => html`<tr><td class="mono">${s.name} <span class="dim">(${s.scope} · ${s.source})</span></td><td>${s.sessions_present}</td><td>${s.invocations}</td><td>${s.estimated_tax_usd_window != null ? fmtCost(s.estimated_tax_usd_window) : ('~' + fmtTokens(s.estimated_tax_tokens_window) + ' tokens')}</td></tr>`)}</tbody></table>
+          <div class="table-wrap"><table class="opt-table"><thead><tr><th>Server</th><th>Sessions</th><th>Invocations</th><th>Tax (window)</th></tr></thead>
+            <tbody>${fd.dead_servers.map(s => html`<tr><td class="mono">${s.name} <span class="dim">(${s.scope} · ${s.source})</span></td><td>${s.sessions_present}</td><td>${s.invocations}</td><td>${s.estimated_tax_usd_window != null ? fmtCost(s.estimated_tax_usd_window) : ('~' + fmtTokens(s.estimated_tax_tokens_window) + ' tokens')}</td></tr>`)}</tbody></table></div>
           ${fd.caveat ? html`<div class="opt-caveat">! ${fd.caveat}</div>` : null}`;
     }
   }
@@ -8454,7 +8459,7 @@ function RecommendationsPanel({ rec }) {
         <div class="sz-tile"><div class="sz-tile-v" style="color:var(--success)">${fmtTokens(measTok)}${measUsd ? ' (' + fmtCost(measUsd) + ')' : ''}</div><div class="sz-tile-l">measured recovered</div></div>
         <div class="sz-tile"><div class="sz-tile-v">${rec.adopted || 0} / ${rec.ignored || 0}</div><div class="sz-tile-l">adopted / ignored</div></div>
       </div>
-      <table class="opt-table" style="margin-top:12px">
+      <div class="table-wrap"><table class="opt-table" style="margin-top:12px">
         <thead><tr><th>When</th><th>What</th><th>Status</th><th style="text-align:right">recovered / est.</th></tr></thead>
         <tbody>
           ${rows.map((o, i) => html`<tr key=${i}>
@@ -8466,7 +8471,7 @@ function RecommendationsPanel({ rec }) {
               : html`<span style="color:var(--accent)">~${fmtTokens(o.estimated_tokens || 0)} est.</span>`}</td>
           </tr>`)}
         </tbody>
-      </table>
+      </table></div>
       <div class="sz-note" style="font-size:12px;margin-top:12px">Measured = observed shift in real spans after a recommendation (a correlation, not proof tokenjam caused it). Estimated = projected at recommendation time. <span class="estimated-tag">honest split</span></div>
     </section>`;
 }
@@ -9701,7 +9706,7 @@ function SummarizeView({ params }) {
               const term = st !== 'staged';
               return html`<tr class=${'cur-row' + (term ? ' added' : '')} key=${i}>
                 <td>${term ? html`<span class="dim">—</span>` : html`<input type="checkbox" checked=${revChecked.has(r.path)} onChange=${() => rvToggle(r.path)} />`}</td>
-                <td class="mono"><span class="sz-link" title="review the diff" onClick=${() => setRevModal(r.path)}>${r.path}</span></td>
+                <td class="mono"><span class="sz-link" title=${r.path + ' — review the diff'} onClick=${() => setRevModal(r.path)}>${shortPath(r.path)}</span></td>
                 <td><span class="dim" style="font-size:12px">${r.kind}</span></td>
                 <td><span class="dim" style="font-size:12px">${r.scope}</span></td>
                 <td class="mono" style="text-align:right;color:var(--accent)">~${r.est_tokens_saved}</td>
@@ -9824,7 +9829,7 @@ function SummarizeView({ params }) {
             const st = statusOf(c);
             return html`<tr class=${'cur-row' + (isAdded ? ' added' : '')} key=${i}>
               <td>${isAdded ? html`<span class="dim" title="in basket">✓</span>` : html`<input type="checkbox" checked=${checked.has(c.path)} onChange=${() => toggle(c.path)} />`}</td>
-              <td class="mono">${c.path}</td>
+              <td class="mono" title=${c.path}>${shortPath(c.path)}</td>
               <td><span class="dim" style="font-size:12px">${c.kind}</span></td>
               <td><span class="dim" style="font-size:12px">${c.scope}</span></td>
               <td class="mono" style="text-align:right">${c.prose_words.toLocaleString()}</td>


### PR DESCRIPTION
Two Lens UI changes to the Dashboard's optimize row.

## Wide tables no longer overflow the page

Every `opt-table` detail table (about 13 render sites: downsize, placement, cache, resend, script, reuse, subagent, verbosity, deadweight, recommendations) was rendered without a `.table-wrap` container, even though that class already existed and was used elsewhere in the app. Cells holding unbreakable content, absolute filesystem paths in the resend finding's recurring-inclusions table and long provider/model strings elsewhere, forced the table, its card and the whole page wider than the viewport. `body` had no `overflow-x` rule, so the page itself scrolled sideways, and because the sidebar is fixed the result was content bleeding past both edges of the content column: the leading part of each path was cut off on the left while the fix column clipped on the right.

Now the page body cannot scroll horizontally, wide tables scroll inside their own container, and long paths truncate with the full value available on hover. The two file-picker listboxes had the same untruncated-path defect and are fixed the same way.

## New total tile on the opportunities row

Adds a total as the first tile in the row, so the per-analyzer figures roll up to one number.

The figure is a plain sum of the per-analyzer opportunities. That is deliberate and scoped: the netted cross-analyzer rollup is the more defensible number in general, but the overlapping-claim double-count it corrects is not in play for the persona this ships to. A comment at the summing site records the decision, and switching the tile to the netted rollup is tracked separately.

Three details worth calling out, since this row is exactly the kind of surface that tends to assert more than its data supports:

- The sum filters on each analyzer's state, not on whether its value is falsy. An analyzer reporting no candidates is excluded from the total rather than contributing a zero.
- While the data is unresolved the tile renders a skeleton, never `$0.00`. A zero there would read as "no waste", which is the worst possible placeholder.
- If only some analyzers have resolved, the tile discloses its coverage ("5 of 6") rather than presenting a figure that implies it covers all of them.

The total also reconciles with what is on screen. Each contributor is rounded to the cent before summing, using the same helper that renders an individual tile, so adding the visible figures by hand always matches the total. Summing raw values first produced a one-cent mismatch.

All seven tiles now fit on one row, and the loading skeleton renders seven placeholders so the row does not reflow when real data arrives.

## Testing

`tests/unit/test_lens_ui_regression.py`, `test_lens_dashboard_states.py` and `test_lens_select_all_behaviour.py`: 102 passed.

New coverage pins the behaviour rather than the markup. The total's arithmetic is tested by extracting the pure function from the served HTML and running it, so wrong arithmetic cannot pass a string grep: an absent analyzer is excluded rather than zeroed, an at-ceiling analyzer contributes nothing, a fully unresolved row is the unknown state and never zero, a partially resolved row discloses its coverage, and the total equals the sum of the displayed figures. That last test was confirmed failing against the previous sum-raw implementation before the fix, so it is not a tautology. The overflow fix is pinned by asserting `body` cannot scroll horizontally and that every `opt-table` render site is wrapped.

Verified in a headless browser against a local build: measured page overflow is 0 with all seven tiles rendered, all seven share one row at full width, and the row wraps rather than squashing at a narrower viewport. Viewports below 900px were not checked; the Lens UI is desktop-only with a fixed sidebar and no mobile layout on this page.
