### PR TITLE
fix(optimize): downsize claude-code card honesty + subagent evidence fix

### DIFF
--- a/tests/unit/test_cost_proposals.py
+++ b/tests/unit/test_cost_proposals.py
@@ -1696,19 +1696,35 @@ def _downsize_finding():
     )
 
 
-def test_downsize_window_wide_card_gives_claude_code_the_cc_lever_not_a_raw_swap():
-    """A claude-code window can't switch its own interactive model mid-
-    session, so the window-wide fallback card must not hand it the raw
-    "route to a cheaper model" instruction an SDK caller gets."""
+def test_downsize_window_wide_card_is_retired_for_claude_code():
+    """DECISION (persona/actionability matrix, downsize row): for
+    ``claude-code``, `downsize` fires ONLY the driver-role card. This used to
+    assert the window-wide card fired with a CC-lever fallback (INVERTED per
+    Critical Rule 23) — that fallback card always ended in "switch your own
+    interactive model", a pointer to other commands rather than a fix, so a
+    claude-code window hit a number with no fix as the common case. The
+    fixture below carries no driver-role fields, so the retired card leaves
+    nothing behind: no cards at all, not a degraded one."""
     from tokenjam.core.optimize.cost_proposals import _downsize_to_proposal
 
     props = _downsize_to_proposal(_downsize_finding(), persona="claude-code")
-    assert len(props) == 1
-    p = props[0]
-    assert "switch your own interactive model" in p.advise_text
-    assert "route to a cheaper" not in p.advise_text.lower()
-    assert "tj route export" in p.advise_text
-    assert p.suggestion == ""  # the unusable model-swap snippet is dropped
+    assert props == []
+
+
+def test_downsize_claude_code_gets_only_the_driver_role_card():
+    """When the SAME finding also carries driver-role data (the common CC
+    shape — a premium model doing undelegated work), claude-code gets exactly
+    that one card and never the tiny-session/per-agent fallback, even though
+    `candidate_sessions` is nonzero."""
+    from tokenjam.core.optimize.cost_proposals import _downsize_to_proposal
+
+    finding = _downsize_finding()
+    finding.driver_sessions = 2
+    finding.driver_recoverable_usd = 5.0
+    finding.driver_substitutes = {"claude-opus-4-8": "claude-sonnet-5"}
+
+    props = _downsize_to_proposal(finding, persona="claude-code")
+    assert [p.signature for p in props] == ["cost:downsize:driver-role"]
 
 
 def test_downsize_window_wide_card_unchanged_for_sdk_and_unknown():

--- a/tests/unit/test_downsize_driver_role.py
+++ b/tests/unit/test_downsize_driver_role.py
@@ -342,3 +342,68 @@ def test_the_driver_card_and_the_tiny_card_do_not_claim_the_same_dollars(db):
     assert sum(p.past_overspend_usd or 0.0 for p in proposals) <= (
         finding.past_overspend_usd + 1e-6
     )
+
+
+# --- project-aware placement of the driver-role claim ------------------------
+#
+# Retiring the tiny-session card for `claude-code` (`_downsize_to_proposal`)
+# touches only which CARDS `cost_proposals` emits. `driver_session_tokens` —
+# what `_placement_weights` and `rule_placement.build_placement_plan` read —
+# is populated by `analyze_model_downgrade` itself, a layer below the card
+# adapters, so it is untouched by that gate. This pins the placement half
+# directly: a driver-role finding whose sessions span two projects still
+# splits into one destination per project rather than merging into one.
+
+def _repo(tmp_path, name: str):
+    root = tmp_path / name
+    (root / ".git").mkdir(parents=True)
+    (root / "CLAUDE.md").write_text("# existing\n", encoding="utf-8")
+    return root
+
+
+def test_driver_role_finding_across_two_projects_splits_into_two_destinations(db, tmp_path):
+    from tokenjam.core.optimize import rule_placement as rp
+    from tokenjam.core.optimize.cost_proposals import _placement_weights
+
+    # Two driver sessions per project — MIN_SESSIONS_PER_DESTINATION is 2, so a
+    # single session per root would fold back into the unresolved pool rather
+    # than earning its own destination.
+    for sid in ("alpha-1", "alpha-2"):
+        _seed_driver_session(db, session_id=sid)
+    for sid in ("beta-1", "beta-2"):
+        _seed_driver_session(db, session_id=sid)
+
+    since, until = _window()
+    report = build_report(
+        db=db, config=TjConfig(version="1"), since=since, until=until,
+        findings=["downsize"],
+    )
+    finding = report.downgrade
+    assert finding is not None
+    assert finding.driver_sessions == 4
+    assert set(finding.driver_session_tokens) == {
+        "alpha-1", "alpha-2", "beta-1", "beta-2",
+    }
+
+    # `_placement_weights` reads that field straight off the finding — the
+    # same layer the claude-code card gate never touches.
+    weights = _placement_weights("downsize", report)
+    assert set(weights) == {"alpha-1", "alpha-2", "beta-1", "beta-2"}
+
+    alpha, beta = _repo(tmp_path, "alpha"), _repo(tmp_path, "beta")
+    cwds = {
+        "alpha-1": str(alpha), "alpha-2": str(alpha),
+        "beta-1": str(beta), "beta-2": str(beta),
+    }
+    plan = rp.build_placement_plan(
+        [rp.SessionShare(sid, weight=w) for sid, w in weights.items()],
+        cwds,
+        total_tokens=int(finding.driver_tokens),
+        total_usd=finding.driver_recoverable_usd,
+        within=tmp_path,
+    )
+    # One write per project, not one merged write, and not one write per
+    # session either.
+    assert {d.root for d in plan.destinations} == {str(alpha), str(beta)}
+    assert sorted(d.sessions for d in plan.destinations) == [2, 2]
+    assert plan.unresolved_sessions == 0

--- a/tests/unit/test_subagent_rubric_contradiction.py
+++ b/tests/unit/test_subagent_rubric_contradiction.py
@@ -95,3 +95,81 @@ def test_the_rubric_does_not_strengthen_any_claim(monkeypatch):
         lowered = text.lower()
         for banned in ("safe to", "would have worked", "no quality", "guaranteed"):
             assert banned not in lowered
+
+
+# --- The evidence= field: a declaration/enforcement pair, not a catalog string -
+#
+# Every test above scans `SUBAGENT_RUBRIC_INTRO` / `RIGHTSIZE_FIX_TEMPLATE` —
+# catalog constants. The `evidence=` sentence on an `over_powered` card is built
+# inline in `cost_proposals._subagent_to_proposals`, at call time, from the
+# finding's own rows: none of the tests above can see it, which is exactly how
+# it said "did little work (small output, few tool calls)" — the
+# `over_provisioned` gate's language, not `over_powered`'s — while every test in
+# this file stayed green. `over_powered` is set by `is_premium_tier(model)` plus
+# `MIN_FLAG_COST_USD` alone (`subagent_rightsizing._flags_for`); it never reads
+# `output_tokens` or `tool_calls`. These tests build a real proposal through the
+# actual construction path and pin the two to AGREE: the evidence states only
+# what the gate tests, on a fixture whose numbers would directly contradict the
+# banned language if it ever came back.
+
+def _over_powered_row(**overrides):
+    from tokenjam.core.optimize.analyzers.subagent_rightsizing import SubagentRow
+
+    fields = dict(
+        session_id="s1", sub_agent_id="sa0", model="claude-opus-4-8",
+        llm_calls=200, tool_calls=340, input_tokens=400_000, output_tokens=40_000,
+        cache_tokens=0, cache_write_tokens=0, cost_usd=6.5, provider="anthropic",
+        flags=["over_powered"],
+    )
+    fields.update(overrides)
+    return SubagentRow(**fields)
+
+
+def test_over_powered_evidence_agrees_with_its_own_gate():
+    """The gate this card fires on (`is_premium_tier` + the cost floor) is what
+    the evidence sentence must state — never output size or tool-call count,
+    which is `over_provisioned`'s test, not this one."""
+    from tokenjam.core.optimize.analyzers.subagent_rightsizing import (
+        SubagentRightsizingFinding,
+    )
+    from tokenjam.core.optimize.cost_proposals import _subagent_to_proposals
+
+    # Deliberately the OPPOSITE of "little work": hundreds of tool calls and a
+    # large output. If the banned language ever came back, this fixture is
+    # exactly the case that would make it self-contradicting on the same card.
+    row = _over_powered_row()
+    finding = SubagentRightsizingFinding(
+        flagged=[row], percent_of_cost=0.5, flagged_cost_usd=6.5,
+        subagent_cost_usd=6.5, past_overspend_usd=2.0, past_overspend_tokens=440_000,
+    )
+    props = _subagent_to_proposals(finding)
+    assert len(props) == 1
+    evidence = props[0].evidence
+
+    # Guard: the extractor actually parsed something. A test asserting only
+    # absence of the banned phrases would pass vacuously against an empty or
+    # unrelated string once the code moves.
+    assert evidence and "premium-tier" in evidence and row.model in evidence
+
+    lowered = evidence.lower()
+    for banned in (
+        "did little work", "small output", "few tool calls",
+        "little tool work", "short result", "short conclusion", "short output",
+    ):
+        assert banned not in lowered, (
+            f"over_powered evidence claims {banned!r}, a property its gate "
+            "never tests"
+        )
+
+
+def test_over_provisioned_keeps_its_own_low_output_language():
+    """The other half of the pair: `over_provisioned` legitimately earns the
+    low-output framing (it is exactly what its gate tests), and it must not
+    lose that language to the fix above. `_derived_effort` (cost_proposals.py)
+    is where that framing survives today — it pins `effort: low` only for an
+    `over_provisioned` row, never for `over_powered` alone."""
+    from tokenjam.core.optimize.cost_proposals import _derived_effort
+
+    assert _derived_effort({"over_provisioned": True}) == "low"
+    assert _derived_effort({"over_provisioned": False}) is None
+    assert _derived_effort({}) is None

--- a/tokenjam/core/optimize/analyzers/model_downgrade.py
+++ b/tokenjam/core/optimize/analyzers/model_downgrade.py
@@ -683,6 +683,15 @@ def analyze_model_downgrade(
     total_savings = savings_window + driver_savings
     monthly_savings = (total_savings / window_days * 30.0) if window_days > 0 else 0.0
     percent = (candidate_sessions / total_sessions * 100.0) if total_sessions else 0.0
+    # Both cases combined — the population `past_overspend_usd` actually sums
+    # over. `percent`/`percent_of_sessions` above stays tiny-session-only (see
+    # its own comment); this is the pair a surface must use beside the dollar
+    # tile, or a driver-role-only window renders a real $ figure next to "0%,
+    # 0 of N" — see `DowngradeFinding.percent_of_all_sessions`.
+    percent_of_all = (
+        ((candidate_sessions + len(driver_aggs)) / total_sessions * 100.0)
+        if total_sessions else 0.0
+    )
     # The confidence interval brackets what the card actually shows, so it has
     # to resample BOTH cases' per-session values, not just the tiny-session one.
     per_session_savings.extend(a.recoverable_usd for a in driver_aggs)
@@ -763,6 +772,7 @@ def analyze_model_downgrade(
         alternative_cost_usd=round(alt_cost, 6),
         monthly_savings_usd=round(monthly_savings, 2),
         percent_of_sessions=round(percent, 1),
+        percent_of_all_sessions=round(percent_of_all, 1),
         examples=examples,
         suggestions=suggestions,
         bench_command=bench_command,

--- a/tokenjam/core/optimize/cost_proposals.py
+++ b/tokenjam/core/optimize/cost_proposals.py
@@ -399,10 +399,15 @@ def _downsize_to_proposal(
     delta-verify pass measures the model-mix cost delta across ALL flagged
     models, so one proposal listing them keeps that aggregate estimate coherent.
 
-    ``persona`` gates the CTA exactly like ``cmd_optimize._render_downgrade_
-    cta`` gates the CLI's: a ``"claude-code"`` window can't switch its own
-    interactive model, so it never gets the raw "route to a cheaper model"
-    instruction — see ``_DOWNSIZE_CC_LEVER``.
+    ``persona`` gates which of the two cards fire, not just their wording.
+    DECISION (persona/actionability matrix, downsize row): for
+    ``"claude-code"``, this analyzer emits ONLY the driver-role card. Both
+    the window-wide and per-agent tiny-session cards end in "switch your own
+    interactive model" for this persona — above the CC actionable ceiling —
+    so a Claude Code reader used to hit a card that stated a number with no
+    fix. Retired for that persona only: ``_downsize_agent_proposals`` and the
+    window-wide card below are unchanged and still fire for ``sdk``, where
+    routing a request to a cheaper model is a real lever.
     """
     if finding is None:
         return []
@@ -413,6 +418,13 @@ def _downsize_to_proposal(
     # Exactly one window-wide card, never one per agent, so this adds at most a
     # single row to the inbox.
     proposals = _driver_role_proposals(finding, persona)
+    if persona == "claude-code":
+        # See the docstring above: the tiny-session/per-agent cards never had
+        # a fix on this persona's action surface, only a pointer to other
+        # commands — retiring them here means a claude-code window either
+        # gets the driver-role card (a real one-paste fix) or nothing, never
+        # a number with no fix attached.
+        return proposals
     if getattr(finding, "candidate_sessions", 0) <= 0:
         return proposals
     per_agent = _downsize_agent_proposals(finding, config, persona)
@@ -1775,10 +1787,20 @@ def _subagent_to_proposals(finding: Any, config: Any = None) -> list[CostProposa
     subagents = len({(r.session_id, r.sub_agent_id) for r in over_powered})
     pct = float(getattr(finding, "percent_of_cost", 0.0) or 0.0) * 100
     model_list = ", ".join(models)
+    # State what the `over_powered` gate actually tests — `is_premium_tier(model)`
+    # plus the cost floor, and NOTHING about output size or tool-call count (see
+    # `subagent_rightsizing._flags_for`). The old wording ("did little work,
+    # small output, few tool calls") described `over_provisioned`'s gate, not
+    # this one, so a dispatch that ran hundreds of tool calls and returned a
+    # large result was told it did little work — contradicting the numbers
+    # rendered on the same card. `over_provisioned` legitimately keeps that
+    # language on its own evidence (see `_derived_effort`); this sentence must
+    # not borrow it.
+    floor = float(getattr(finding, "min_flag_cost_usd", 0.0) or 0.0)
     evidence = (
         f"{subagents} subagent dispatch(es) ran on a premium-tier model "
-        f"({model_list}) but did little work (small output, few tool calls). "
-        f"Subagents are {pct:.0f}% of the window's cost."
+        f"({model_list}), above the {_money(floor)} per-dispatch cost floor "
+        f"this flag applies. Subagents are {pct:.0f}% of the window's cost."
     )
     # The trailing sentence here used to RESTATE the rubric — "route that shape
     # to the cheaper same-family model next time" is the rubric's own core

--- a/tokenjam/core/optimize/types.py
+++ b/tokenjam/core/optimize/types.py
@@ -146,15 +146,27 @@ class DowngradeFinding:
     estimate_basis:               str          = ""
     estimate_confidence:          str          = "heuristic"
     # Sampling confidence (#308). `n_sessions` is the candidate-session sample
-    # the projection rests on; `ci_low`/`ci_high` are the 95% bootstrap interval
-    # on `monthly_savings_usd`, so a 5-session estimate shows a visibly wider
-    # band than a 500-session one. This is SAMPLING confidence on the projection,
-    # NOT a claim the model swap preserves quality — the MODEL_DOWNGRADE_CAVEAT
-    # still governs that. ci_low/ci_high are None when n < 2 (no spread to
-    # estimate from a single point).
+    # the projection rests on — BOTH cases combined (`candidate_sessions +
+    # driver_sessions`), since `past_overspend_usd` is their sum too; `ci_low`/
+    # `ci_high` are the 95% bootstrap interval on `monthly_savings_usd`, so a
+    # 5-session estimate shows a visibly wider band than a 500-session one.
+    # This is SAMPLING confidence on the projection, NOT a claim the model
+    # swap preserves quality — the MODEL_DOWNGRADE_CAVEAT still governs that.
+    # ci_low/ci_high are None when n < 2 (no spread to estimate from a single
+    # point).
     n_sessions:                   int          = 0
     ci_low:                       float | None = None
     ci_high:                      float | None = None
+    # `n_sessions / total_sessions`, as a percent — the population this finding's
+    # ONE `past_overspend_usd` actually covers (both cases). `percent_of_sessions`
+    # above covers the tiny-session case ALONE, so a surface that renders the
+    # dollar tile beside a "N of M sessions" stat must use THIS pair
+    # (`n_sessions`/`percent_of_all_sessions`), never `candidate_sessions`/
+    # `percent_of_sessions` — a window where the driver-role case carries the
+    # whole figure has `candidate_sessions == 0`, which would render a real
+    # dollar amount beside "0%, 0 of N" (two figures over two different
+    # populations shown together).
+    percent_of_all_sessions:      float        = 0.0
     # Per-agent price arithmetic for the proposed swap (one
     # `analyzers.downsize_agents.AgentPriceRow` per agent/model group over the
     # candidate sessions): exact per-type tokens at the current model's rates

--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -7635,7 +7635,15 @@ function HealthTile({ label, value, attention, href, sub, status = 'ready' }) {
 function optDetailStats(name, fd, dg) {
   if (name === 'downsize') {
     if (!dg) return [null, null];
-    return [{ v: dg.percent_of_sessions + '%', l: 'of sessions match' }, { v: dg.candidate_sessions + ' / ' + dg.total_sessions, l: 'candidate sessions' }];
+    // `n_sessions`/`percent_of_all_sessions`, not `candidate_sessions`/
+    // `percent_of_sessions`: the latter pair covers the tiny-session case
+    // ALONE, while stat tile 1 (past overspend, rendered by the caller) sums
+    // BOTH the tiny-session and driver-role cases. A driver-role-only window
+    // has `candidate_sessions === 0`, which rendered a real dollar figure
+    // beside "0%, 0 of N" — two figures over two different populations shown
+    // together. `n_sessions`/`percent_of_all_sessions` cover the SAME
+    // population the dollar figure does.
+    return [{ v: dg.percent_of_all_sessions + '%', l: 'of sessions flagged' }, { v: dg.n_sessions + ' / ' + dg.total_sessions, l: 'flagged sessions' }];
   }
   if (!fd) return [null, null];
   if (name === 'placement') return [{ v: String(fd.candidates.length), l: 'workloads fit the batch shape' }, { v: fd.percent_of_window_cost + '%', l: 'of window cost' }];
@@ -7704,7 +7712,19 @@ function OptimizeFinding({ name, opt, framing, proposals, onProposalChanged, onP
     body = !dg ? html`
       <div class="opt-line dim">No downsize candidates in this window; sessions don't match the smaller-model shape (small input/output, few tool calls).</div>`
       : html`
-      <div class="opt-line">${dg.percent_of_sessions}% of sessions match a smaller-model candidate shape (${dg.candidate_sessions} of ${dg.total_sessions}).</div>
+      ${/* Two DISJOINT populations feed this one finding (see
+           model_downgrade.py): a premium model driving undelegated work
+           (below) and structurally tiny sessions that match a candidate
+           shape (further below). Each sentence is gated on its OWN
+           population rather than always rendering both — a driver-role-only
+           window has `candidate_sessions === 0`, and printing "0% ... 0 of
+           N" next to the real dollar figure above claimed a different
+           population than the one the tile actually sums (root anti-pattern
+           22). Labelling each figure with the population it covers, per the
+           same rule, beats merging them into one number that would overstate
+           the tiny-session shape's own share. */ ''}
+      ${dg.driver_sessions ? html`<div class="opt-line">${dg.driver_sessions} session(s) ran a premium model in the driver role, undelegated: ${fmtCost(dg.driver_recoverable_usd)} of the figure above.</div>` : null}
+      ${dg.candidate_sessions ? html`<div class="opt-line">${dg.percent_of_sessions}% of sessions match a smaller-model candidate shape (${dg.candidate_sessions} of ${dg.total_sessions}).</div>` : null}
       ${dg.suggestions && Object.keys(dg.suggestions).length ? html`<div class="opt-line dim">Pattern: ${Object.entries(dg.suggestions).map(([k, v]) => k + ' → ' + v).join(', ')}</div>` : null}
       ${(dg.examples || []).length ? html`<div class="opt-sub">Examples</div>
         <div class="table-wrap"><table class="opt-table"><tbody>${dg.examples.map(ex => html`<tr><td class="mono">${(ex.trace_id || '').slice(0, 8)}…</td><td>${ex.tool_calls} tools</td><td class="mono">${ex.model}</td></tr>`)}</tbody></table></div>` : null}`;


### PR DESCRIPTION
## What was wrong

**1. `downsize` handed a Claude Code user a card that ended in no fix.**

`downsize` emits two differently-gated cards: a tiny-session model-swap card
and a driver-role card (fires when a premium model does undelegated work
inline). The tiny-session card unconditionally blanked its suggestion for the
`claude-code` persona and fell back to advisory prose pointing at other
commands — so a Claude Code user's common case was a card that stated a
number with no fix attached. The driver-role card, which ships a real
one-paste CLAUDE.md fix, is persona-agnostic and already worked correctly.

The same finding also produced mismatched figures on the downsize detail
page: the past-overspend stat tile rendered a real dollar figure (both cases
summed), while the candidate-list stats on the same page — scoped to the
tiny-session case alone — read `0%` / "0 of N" whenever the driver-role case
carried the whole number.

**2. Every `over_powered` subagent card asserted a property its own gate
never tests.**

The evidence sentence said a flagged dispatch "did little work (small
output, few tool calls)." But `over_powered` is set by `is_premium_tier(model)`
plus a cost floor alone (`subagent_rightsizing._flags_for`) — it never reads
output size or tool-call count. That test belongs to the separate
`over_provisioned` flag. So a dispatch that ran hundreds of tool calls and
returned a large result was told it did little work, directly contradicted
by the numbers rendered on the same card.

## What changed

- `tokenjam/core/optimize/cost_proposals.py`: `_downsize_to_proposal` now
  returns only the driver-role proposal for the `claude-code` persona,
  never building the tiny-session/per-agent cards for it. Those cards are
  unchanged and still fire for `sdk`, where routing a request to a cheaper
  model is a real, actionable lever. The `over_powered` evidence sentence
  now states what its gate actually tests (a premium-tier model above the
  per-dispatch cost floor) instead of borrowing `over_provisioned`'s
  low-output language.
- `tokenjam/core/optimize/types.py` / `analyzers/model_downgrade.py`: added
  `DowngradeFinding.percent_of_all_sessions`, computed alongside the existing
  `n_sessions` field, so a surface pairing the dollar tile with a session
  count can read the SAME population the dollar figure sums (both cases)
  instead of the tiny-session-only `candidate_sessions` /
  `percent_of_sessions` pair.
- `tokenjam/ui/index.html`: the downsize detail page's stat tiles now read
  `n_sessions` / `percent_of_all_sessions`. The inline evidence line is split
  into two population-scoped sentences (driver-role, tiny-session), each
  gated on its own population being nonzero, rather than one sentence that
  could show "0 of N" beside a real dollar figure it does not describe.

## How it's pinned

- `tests/unit/test_cost_proposals.py`: the old test asserting the tiny-session
  CC-lever fallback fired is inverted (the fallback card no longer fires at
  all for `claude-code`); a new test confirms a finding carrying both cases
  yields exactly the driver-role card for that persona.
- `tests/unit/test_subagent_rubric_contradiction.py`: the existing regression
  test in this file only scanned catalog constants (`SUBAGENT_RUBRIC_INTRO`,
  `RIGHTSIZE_FIX_TEMPLATE`), so it was structurally blind to the `evidence=`
  field built inline at proposal-construction time — exactly where the
  contradiction lived. New tests build a real `CostProposal` through the
  actual construction path on a fixture that is deliberately the opposite of
  "little work" (large output, hundreds of tool calls), assert the evidence
  text agrees with what `over_powered`'s gate tests, and guard that the
  extractor actually found the expected content so the check can't pass
  vacuously. A companion test confirms `over_provisioned` keeps its own
  low-output framing.
- `tests/unit/test_downsize_driver_role.py`: a new test proves the persona
  gate on the CARD layer doesn't touch the placement layer — a driver-role
  finding whose sessions are seeded across two project roots still splits
  into one destination per project, via the same `driver_session_tokens` /
  `_placement_weights` / `rule_placement.build_placement_plan` path the
  finding always used.

Ran the touched suites plus the surrounding persona/placement/UI tests
locally (`test_downsize_driver_role.py`, `test_downsize_agent_pricing.py`,
`test_subagent_rubric_contradiction.py`, `test_rollup_subagent_downsize_dedup.py`,
`test_cost_proposals.py`, `test_rule_placement.py`, `test_persona_analyzer_gate.py`,
`test_lens_module_parses.py`, `test_ui_offline.py`, and the relevant
integration CLI/API tests) — all green.

## Doc correction

Also corrected the internal analyzer decision record (not part of this repo)
that previously described `downsize` with a single verdict covering only the
tiny-session card, which read as "this analyzer has no fix" for Claude Code
even though the driver-role card already shipped a real one.
