### PR TITLE
chore: bump version to 0.6.8

### DIFF
--- a/npm-wrapper/package.json
+++ b/npm-wrapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenjam",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "Zero-install launcher for TokenJam (tj): npx tokenjam runs the Python CLI via uvx/pipx and reports the recurring mistakes your AI agent keeps repeating, no setup required.",
   "keywords": ["claude-code", "ccusage", "tokens", "cost-optimization", "llm", "agents", "observability", "tokenjam", "anthropic", "claude", "token-usage", "agent-behavior", "cli", "statusline", "opentelemetry", "agent-observability"],
   "homepage": "https://tokenjam.dev",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tokenjam"
-version = "0.6.7"
+version = "0.6.8"
 description = "TokenJam: a local-first, OTel-native cost-saving utility for AI agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenjam/sdk",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "TypeScript SDK for TokenJam — local-first observability for AI agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/tokenjam/core/optimize/runner.py
+++ b/tokenjam/core/optimize/runner.py
@@ -77,8 +77,10 @@ ANALYZER_ORDER: list[str] = [
 # An analyzer that misses any one of those has no business spending query
 # time for that persona. Each entry below records which one it misses.
 #
-# `mixed` / `sdk` / `unknown` disable nothing: the conservative default is to
-# run everything, so an unclassified window never silently loses a finding.
+# `mixed` / `unknown` disable nothing: the conservative default is to run
+# everything, so an unclassified window never silently loses a finding.
+# `sdk` has its own key below, gating analyzers whose data source doesn't
+# exist for that persona.
 PERSONA_DISABLED_ANALYZERS: dict[str, frozenset[str]] = {
     # An interactive coding agent's harness constructs the API request, picks
     # the model for its own main thread, and owns the prompt template. The


### PR DESCRIPTION
Bumps the three lockstep version files to 0.6.8 ahead of cutting the release.

Also carries a small stale-comment fix in `optimize/runner.py` (the persona gate comment claimed a shared key; the SDK persona has its own).

Release contents since v0.6.7: the lens redesign (#699), the write-budget purge (#707), the analyzer prose re-sentencing (#708), and the analyzer card honesty fix (#709).
