### PR TITLE
fix(storage): cap the per-span system prefix and bound DuckDB's buffer pool

### DIFF
--- a/tests/unit/test_backfill.py
+++ b/tests/unit/test_backfill.py
@@ -922,6 +922,12 @@ def test_capture_off_extracts_no_content_only_provenance(tmp_path):
         GenAIAttributes.PROMPT_CONTENT, GenAIAttributes.COMPLETION_CONTENT,
         GenAIAttributes.TOOL_INPUT, GenAIAttributes.TOOL_OUTPUT,
         TjAttributes.SYSTEM_PREFIX_CONTENT,
+        # The compact prefix keys ride the same capture toggle: SAMPLE is
+        # literal prompt text, and HASH/LENGTH are a fingerprint of a file the
+        # user just said not to capture.
+        TjAttributes.SYSTEM_PREFIX_HASH,
+        TjAttributes.SYSTEM_PREFIX_SAMPLE,
+        TjAttributes.SYSTEM_PREFIX_LENGTH,
     }
     for span in (llm, tool):
         assert span.attributes["source"] == "backfill.claude_code"
@@ -999,9 +1005,15 @@ def test_capture_prompts_reads_project_claude_md_as_system_prefix(tmp_path):
     """#272: the human's per-turn message never repeats verbatim, so
     cache-recommend's prefix-hash needs a different, genuinely stable
     signal. The project's CLAUDE.md is read straight off disk (it's not in
-    the transcript) and stamped as `TjAttributes.SYSTEM_PREFIX_CONTENT` --
+    the transcript) and stamped as `TjAttributes.SYSTEM_PREFIX_HASH` --
     identical on every assistant span for the same project, unlike
-    PROMPT_CONTENT."""
+    PROMPT_CONTENT.
+
+    The prefix is stored as a fingerprint rather than as the text: it was the
+    same value on every span, so keeping it whole cost (size x span count).
+    What this asserts is unchanged -- that a stable per-project signal exists
+    and that it is NOT the per-turn prompt."""
+    from tokenjam.core.system_prefix import prefix_hash
     from tokenjam.otel.semconv import TjAttributes
 
     project_dir = tmp_path / "proj"
@@ -1031,9 +1043,11 @@ def test_capture_prompts_reads_project_claude_md_as_system_prefix(tmp_path):
     assert parsed is not None
     llm_spans = [s for s in parsed.spans if s.name == "gen_ai.llm.call"]
     assert len(llm_spans) == 2
+    expected = prefix_hash("# Project rules\nAlways use tabs.")
     for span in llm_spans:
-        assert span.attributes[TjAttributes.SYSTEM_PREFIX_CONTENT] == \
-            "# Project rules\nAlways use tabs."
+        assert span.attributes[TjAttributes.SYSTEM_PREFIX_HASH] == expected
+        # The text itself is never stored -- that is the 4.06 GB defect.
+        assert TjAttributes.SYSTEM_PREFIX_CONTENT not in span.attributes
     # The per-turn human prompt still differs call to call -- confirming the
     # two signals are genuinely distinct, not the same field renamed.
     assert llm_spans[0].attributes[GenAIAttributes.PROMPT_CONTENT] == "turn one"
@@ -1043,6 +1057,7 @@ def test_capture_prompts_reads_project_claude_md_as_system_prefix(tmp_path):
     # prompts=False captures neither.
     parsed_off = parse_claude_code_session(path, capture=CaptureConfig(prompts=False))
     llm_off = next(s for s in parsed_off.spans if s.name == "gen_ai.llm.call")
+    assert TjAttributes.SYSTEM_PREFIX_HASH not in llm_off.attributes
     assert TjAttributes.SYSTEM_PREFIX_CONTENT not in llm_off.attributes
 
 
@@ -1051,6 +1066,7 @@ def test_claude_md_lookup_retries_after_a_record_with_no_cwd(tmp_path):
     A leading record with no `cwd` can't resolve anything, so it must NOT
     commit the `""` outcome -- doing so locked the sentinel permanently and
     every later record that DID carry a cwd silently lost its system prefix."""
+    from tokenjam.core.system_prefix import prefix_hash
     from tokenjam.otel.semconv import TjAttributes
 
     project_dir = tmp_path / "proj"
@@ -1082,8 +1098,8 @@ def test_claude_md_lookup_retries_after_a_record_with_no_cwd(tmp_path):
     llm_spans = [s for s in parsed.spans if s.name == "gen_ai.llm.call"]
     assert len(llm_spans) == 2
     # The retry happened: the later, cwd-bearing record resolved the file.
-    assert llm_spans[-1].attributes[TjAttributes.SYSTEM_PREFIX_CONTENT] == \
-        "# Project rules\nAlways use tabs."
+    assert llm_spans[-1].attributes[TjAttributes.SYSTEM_PREFIX_HASH] == \
+        prefix_hash("# Project rules\nAlways use tabs.")
 
 
 def test_capture_prompts_on_without_claude_md_omits_system_prefix(tmp_path):
@@ -1094,6 +1110,7 @@ def test_capture_prompts_on_without_claude_md_omits_system_prefix(tmp_path):
     path = _content_session_file(tmp_path)
     parsed = parse_claude_code_session(path, capture=CaptureConfig(prompts=True))
     llm, _tool = _llm_and_tool(parsed)
+    assert TjAttributes.SYSTEM_PREFIX_HASH not in llm.attributes
     assert TjAttributes.SYSTEM_PREFIX_CONTENT not in llm.attributes
 
 

--- a/tests/unit/test_cache_recommend.py
+++ b/tests/unit/test_cache_recommend.py
@@ -460,3 +460,51 @@ def test_render_cache_recommend_snippet_uses_plain_console_print(db, capsys):
     out = capsys.readouterr().out
 
     assert c.cache_control_snippet in out
+
+
+def test_system_prefix_capture_covers_hash_window():
+    """The capture cap must never fall below the window the analyzer hashes.
+
+    `_read_project_claude_md` truncates to `SYSTEM_PREFIX_CAPTURE_CHARS` because
+    nothing downstream reads past `PREFIX_HASH_BYTES`. That is only true while
+    the cap is >= the hash window: drop it under, and two different prefixes
+    that diverge after the cap start colliding onto one hash — the analyzer
+    would merge unrelated prefixes into a single candidate and report an
+    occurrence count that was never real. Nothing else would fail.
+    """
+    from tokenjam.core.optimize.analyzers.cache_recommend import PREFIX_HASH_BYTES
+    from tokenjam.otel.semconv import TjAttributes
+
+    assert TjAttributes.SYSTEM_PREFIX_CAPTURE_CHARS >= PREFIX_HASH_BYTES
+
+
+def test_read_project_claude_md_truncates_to_capture_cap(tmp_path):
+    """A large CLAUDE.md is stored capped, not whole — the 4 GB defect.
+
+    Also pins the behaviour-preserving half of the claim: the truncated value
+    hashes to the same prefix as the full text, so existing candidates keep
+    their identity across the change.
+    """
+    from tokenjam.core.backfill import _read_project_claude_md
+    from tokenjam.core.optimize.analyzers.cache_recommend import _prefix_hash
+    from tokenjam.otel.semconv import TjAttributes
+
+    full = "x" * 50_000
+    (tmp_path / "CLAUDE.md").write_text(full, encoding="utf-8")
+
+    captured = _read_project_claude_md(str(tmp_path))
+
+    assert len(captured) == TjAttributes.SYSTEM_PREFIX_CAPTURE_CHARS
+    assert _prefix_hash(captured) == _prefix_hash(full)
+    # Still comfortably over the analyzer's own `len(text) < 200` skip.
+    assert len(captured) >= 200
+
+
+def test_read_project_claude_md_leaves_short_files_intact(tmp_path):
+    """Under the cap, nothing is removed — truncation is not a rewrite."""
+    from tokenjam.core.backfill import _read_project_claude_md
+
+    body = "# rules\n" + ("short enough\n" * 10)
+    (tmp_path / "CLAUDE.md").write_text(body, encoding="utf-8")
+
+    assert _read_project_claude_md(str(tmp_path)) == body

--- a/tests/unit/test_cache_recommend.py
+++ b/tests/unit/test_cache_recommend.py
@@ -462,49 +462,178 @@ def test_render_cache_recommend_snippet_uses_plain_console_print(db, capsys):
     assert c.cache_control_snippet in out
 
 
-def test_system_prefix_capture_covers_hash_window():
-    """The capture cap must never fall below the window the analyzer hashes.
+# --- the system prefix is stored compactly, not as text -----------------------
+#
+# It used to be stored whole: 92,514 spans each holding a ~43 KB copy of one of
+# 61 distinct files, 4.06 GB of database to carry 1.84 MB of distinct text. The
+# analyzer never read it as text — it hashed a fixed head, kept 120 characters
+# for display, and compared a length. These pin that the compact form carries
+# all three answers, that legacy spans still work, and that nothing silently
+# reintroduces the weight.
 
-    `_read_project_claude_md` truncates to `SYSTEM_PREFIX_CAPTURE_CHARS` because
-    nothing downstream reads past `PREFIX_HASH_BYTES`. That is only true while
-    the cap is >= the hash window: drop it under, and two different prefixes
-    that diverge after the cap start colliding onto one hash — the analyzer
-    would merge unrelated prefixes into a single candidate and report an
-    occurrence count that was never real. Nothing else would fail.
-    """
-    from tokenjam.core.optimize.analyzers.cache_recommend import PREFIX_HASH_BYTES
+
+def test_backfill_stores_a_fingerprint_not_the_file(tmp_path):
+    """The defect, stated as a property: a big CLAUDE.md must not make a big span."""
+    from tokenjam.core.backfill import _read_project_claude_md, _system_prefix_attrs
     from tokenjam.otel.semconv import TjAttributes
 
-    assert TjAttributes.SYSTEM_PREFIX_CAPTURE_CHARS >= PREFIX_HASH_BYTES
+    marker = "PROJECT-RULES-MARKER"
+    (tmp_path / "CLAUDE.md").write_text(marker + ("\nrule line" * 6000), encoding="utf-8")
+
+    text = _read_project_claude_md(str(tmp_path))
+    attrs = _system_prefix_attrs(text)
+
+    assert len(text) > 50_000, "fixture should be a genuinely large file"
+    stored = sum(len(str(v)) for v in attrs.values())
+    assert stored < 300, f"stored {stored} bytes of a {len(text)}-byte file"
+    assert TjAttributes.SYSTEM_PREFIX_CONTENT not in attrs
+    assert not any(marker in str(v) for k, v in attrs.items()
+                   if k != TjAttributes.SYSTEM_PREFIX_SAMPLE), \
+        "only the display sample may quote the file"
 
 
-def test_read_project_claude_md_truncates_to_capture_cap(tmp_path):
-    """A large CLAUDE.md is stored capped, not whole — the 4 GB defect.
+def test_stored_hash_matches_what_the_analyzer_computes_from_text():
+    """Identity must survive the change of storage.
 
-    Also pins the behaviour-preserving half of the claim: the truncated value
-    hashes to the same prefix as the full text, so existing candidates keep
-    their identity across the change.
+    A span stamped with the compact hash and a legacy span carrying the same
+    text have to land in the SAME candidate. If they didn't, one project's
+    calls would split across two candidates after the upgrade and both
+    occurrence counts would be wrong with nothing failing.
     """
-    from tokenjam.core.backfill import _read_project_claude_md
+    from tokenjam.core.backfill import _system_prefix_attrs
     from tokenjam.core.optimize.analyzers.cache_recommend import _prefix_hash
     from tokenjam.otel.semconv import TjAttributes
 
-    full = "x" * 50_000
-    (tmp_path / "CLAUDE.md").write_text(full, encoding="utf-8")
+    text = "# rules\n" + ("a repeated instruction line\n" * 500)
+    stamped = _system_prefix_attrs(text)[TjAttributes.SYSTEM_PREFIX_HASH]
 
-    captured = _read_project_claude_md(str(tmp_path))
-
-    assert len(captured) == TjAttributes.SYSTEM_PREFIX_CAPTURE_CHARS
-    assert _prefix_hash(captured) == _prefix_hash(full)
-    # Still comfortably over the analyzer's own `len(text) < 200` skip.
-    assert len(captured) >= 200
+    assert stamped == _prefix_hash(text)
 
 
-def test_read_project_claude_md_leaves_short_files_intact(tmp_path):
-    """Under the cap, nothing is removed — truncation is not a rewrite."""
-    from tokenjam.core.backfill import _read_project_claude_md
+def test_hash_window_is_single_sourced():
+    """The analyzer's window and the parser's must be one constant.
 
-    body = "# rules\n" + ("short enough\n" * 10)
-    (tmp_path / "CLAUDE.md").write_text(body, encoding="utf-8")
+    They were two copies of the same three lines. Divergence has no symptom —
+    it just quietly regroups spans — so the guard is that both route through
+    `core.system_prefix`.
+    """
+    from tokenjam.core import system_prefix
+    from tokenjam.core.optimize.analyzers.cache_recommend import PREFIX_HASH_BYTES
 
-    assert _read_project_claude_md(str(tmp_path)) == body
+    assert PREFIX_HASH_BYTES == system_prefix.HASH_CHARS
+
+
+def test_two_prefixes_differing_after_the_window_are_one_candidate():
+    """States what the window MEANS, so a change to it is a deliberate one.
+
+    Anything shared past HASH_CHARS is the same cacheable prefix by this
+    product's definition; the tail is what a breakpoint would not cover.
+    """
+    from tokenjam.core import system_prefix
+
+    head = "x" * system_prefix.HASH_CHARS
+    assert system_prefix.prefix_hash(head + "tail A") == \
+           system_prefix.prefix_hash(head + "tail B")
+    assert system_prefix.prefix_hash("y" + head) != system_prefix.prefix_hash(head)
+
+
+def test_short_prefix_keeps_its_real_length(tmp_path):
+    """Below the cacheable floor the analyzer must still be able to skip it."""
+    from tokenjam.core.backfill import _read_project_claude_md, _system_prefix_attrs
+    from tokenjam.otel.semconv import TjAttributes
+
+    (tmp_path / "CLAUDE.md").write_text("tiny", encoding="utf-8")
+    attrs = _system_prefix_attrs(_read_project_claude_md(str(tmp_path)))
+
+    assert attrs[TjAttributes.SYSTEM_PREFIX_LENGTH] == 4
+
+
+def test_capture_off_strips_every_system_prefix_key():
+    """Turning capture off must not leave a fingerprint of the file behind."""
+    from tokenjam.core.ingest import strip_captured_content
+    from tokenjam.otel.semconv import TjAttributes
+
+    attrs = {
+        TjAttributes.SYSTEM_PREFIX_CONTENT: "the whole file",
+        TjAttributes.SYSTEM_PREFIX_HASH: "deadbeefdeadbeef",
+        TjAttributes.SYSTEM_PREFIX_SAMPLE: "first 120 chars",
+        TjAttributes.SYSTEM_PREFIX_LENGTH: 40000,
+        "keep.me": "untouched",
+    }
+    stripped = strip_captured_content(attrs, CaptureConfig(prompts=False))
+
+    assert stripped.get("keep.me") == "untouched"
+    for key in (TjAttributes.SYSTEM_PREFIX_CONTENT, TjAttributes.SYSTEM_PREFIX_HASH,
+                TjAttributes.SYSTEM_PREFIX_SAMPLE, TjAttributes.SYSTEM_PREFIX_LENGTH):
+        assert key not in stripped, key
+
+
+def _seed_prefix_spans(db, *, attrs: dict, count: int, start_offset: int = 0):
+    """Insert N spans carrying an arbitrary system-prefix attribute shape."""
+    start = datetime(2026, 5, 10, tzinfo=timezone.utc)
+    for i in range(count):
+        db.insert_span(make_llm_span(
+            agent_id="test-agent", provider="anthropic", billing_account="anthropic",
+            model="claude-sonnet-4-6", input_tokens=2500, cost_usd=0.005,
+            start_time=start + timedelta(minutes=start_offset + i),
+            extra_attributes=dict(attrs),
+        ))
+
+
+def _cache_finding(db):
+    return build_report(
+        db=db, config=_config(capture_prompts=True),
+        since=datetime(2026, 5, 1, tzinfo=timezone.utc),
+        until=datetime(2026, 5, 30, tzinfo=timezone.utc),
+        findings=["cache-recommend"],
+    ).findings["cache-recommend"]
+
+
+def test_compact_prefix_spans_produce_a_candidate(db):
+    """End-to-end: the analyzer works off the stored fingerprint alone."""
+    from tokenjam.core.backfill import _system_prefix_attrs
+
+    text = "# global rules\n" + ("an instruction that repeats\n" * 400)
+    _seed_prefix_spans(db, attrs=_system_prefix_attrs(text), count=5)
+
+    finding = _cache_finding(db)
+
+    assert finding.enabled
+    assert len(finding.candidates) == 1
+    assert finding.candidates[0].occurrences == 5
+    assert finding.candidates[0].sample_chars  # display survives the change
+
+
+def test_legacy_and_compact_spans_land_in_one_candidate(db):
+    """The upgrade must not split a project's history in two.
+
+    Every span backfilled before this change carries the text; every one after
+    carries the fingerprint. They describe the SAME prefix, so they have to
+    group together — otherwise the day the release ships, one project's calls
+    appear as two candidates and both occurrence counts are understated, with
+    nothing failing to say so.
+    """
+    from tokenjam.core.backfill import _system_prefix_attrs
+    from tokenjam.otel.semconv import TjAttributes
+
+    text = "# global rules\n" + ("an instruction that repeats\n" * 400)
+
+    _seed_prefix_spans(db, attrs={TjAttributes.SYSTEM_PREFIX_CONTENT: text},
+                       count=4, start_offset=0)
+    _seed_prefix_spans(db, attrs=_system_prefix_attrs(text),
+                       count=3, start_offset=100)
+
+    finding = _cache_finding(db)
+
+    assert len(finding.candidates) == 1, \
+        f"history split into {len(finding.candidates)} candidates"
+    assert finding.candidates[0].occurrences == 7
+
+
+def test_a_prefix_under_the_floor_is_still_skipped(db):
+    """The length gate has to work off the stored length, not the sample."""
+    from tokenjam.core.backfill import _system_prefix_attrs
+
+    _seed_prefix_spans(db, attrs=_system_prefix_attrs("too short to cache"), count=5)
+
+    assert _cache_finding(db).candidates == []

--- a/tokenjam/core/backfill.py
+++ b/tokenjam/core/backfill.py
@@ -325,13 +325,29 @@ def _read_project_claude_md(cwd: str | None) -> str:
     system prompt goes out with every request — which is exactly the
     stable, repeated prefix cache-recommend looks for. Returns "" when cwd is
     unknown or the file is missing/unreadable; never raises.
+
+    **Truncated to the number of characters the consumer actually reads.**
+    `cache_recommend` uses this value three ways and no others: it hashes
+    `text[:PREFIX_HASH_BYTES]`, it keeps `text[:120]` as the display sample, and
+    it skips the span when `len(text) < 200`. Nothing downstream ever looks past
+    character `PREFIX_HASH_BYTES`, so storing the rest is pure weight — and it
+    is weight paid *per span*, on a value that is identical across every span of
+    a project. Measured on a real machine: 92,514 spans each holding a ~43 KB
+    copy of 61 distinct files, 4.06 GB on disk to carry 1.8 MB of distinct text,
+    which then had to be paged through DuckDB's buffer pool on every scan.
+
+    Truncating here is behaviour-preserving rather than a trade-off: for a file
+    longer than the cap the hash and the sample are computed from bytes that all
+    survive, and the length gate still sees a value well over 200; for a shorter
+    file nothing is removed at all.
     """
     if not cwd:
         return ""
     try:
-        return (Path(cwd) / "CLAUDE.md").read_text(encoding="utf-8", errors="replace")
+        text = (Path(cwd) / "CLAUDE.md").read_text(encoding="utf-8", errors="replace")
     except OSError:
         return ""
+    return text[:TjAttributes.SYSTEM_PREFIX_CAPTURE_CHARS]
 
 
 def _provider_for_model(model: str) -> str:

--- a/tokenjam/core/backfill.py
+++ b/tokenjam/core/backfill.py
@@ -24,11 +24,12 @@ import logging
 from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Iterator
+from typing import Any, Iterator
 
 from tokenjam.core.cost import calculate_cost
 from tokenjam.core.distill import is_tokenjam_invoke_cwd
 from tokenjam.core.pricing import classify_pricing_source
+from tokenjam.core import system_prefix
 from tokenjam.core.config import CaptureConfig
 from tokenjam.core.method_capture import capture_session_method
 from tokenjam.core.optimize.repeat_task import hash_task_statement
@@ -326,28 +327,39 @@ def _read_project_claude_md(cwd: str | None) -> str:
     stable, repeated prefix cache-recommend looks for. Returns "" when cwd is
     unknown or the file is missing/unreadable; never raises.
 
-    **Truncated to the number of characters the consumer actually reads.**
-    `cache_recommend` uses this value three ways and no others: it hashes
-    `text[:PREFIX_HASH_BYTES]`, it keeps `text[:120]` as the display sample, and
-    it skips the span when `len(text) < 200`. Nothing downstream ever looks past
-    character `PREFIX_HASH_BYTES`, so storing the rest is pure weight — and it
-    is weight paid *per span*, on a value that is identical across every span of
-    a project. Measured on a real machine: 92,514 spans each holding a ~43 KB
-    copy of 61 distinct files, 4.06 GB on disk to carry 1.8 MB of distinct text,
-    which then had to be paged through DuckDB's buffer pool on every scan.
-
-    Truncating here is behaviour-preserving rather than a trade-off: for a file
-    longer than the cap the hash and the sample are computed from bytes that all
-    survive, and the length gate still sees a value well over 200; for a shorter
-    file nothing is removed at all.
+    The text is read in full but **never stored** — see
+    `_system_prefix_attrs`, which reduces it to the three values the analyzer
+    actually consumes before it reaches a span.
     """
     if not cwd:
         return ""
     try:
-        text = (Path(cwd) / "CLAUDE.md").read_text(encoding="utf-8", errors="replace")
+        return (Path(cwd) / "CLAUDE.md").read_text(encoding="utf-8", errors="replace")
     except OSError:
         return ""
-    return text[:TjAttributes.SYSTEM_PREFIX_CAPTURE_CHARS]
+
+
+def _system_prefix_attrs(text: str) -> dict[str, Any]:
+    """The prefix as it goes onto a span: identity, a display sample, a length.
+
+    Storing the text itself is what took a real database to 4.06 GB — the value
+    is identical across every span of a project, so its cost is (size x span
+    count), and 92,514 spans were each holding a ~43 KB copy of one of 61
+    distinct files. `cache_recommend` never used the text as text: it hashed a
+    fixed-size head of it, kept 120 characters for display, and compared its
+    length against a floor. All three survive here at ~230 bytes per span.
+
+    Derivation lives in `core.system_prefix` so the producer and the consumer
+    cannot drift on what a prefix's identity is.
+    """
+    summary = system_prefix.summarize(text)
+    if not summary:
+        return {}
+    return {
+        TjAttributes.SYSTEM_PREFIX_HASH: summary["hash"],
+        TjAttributes.SYSTEM_PREFIX_SAMPLE: summary["sample"],
+        TjAttributes.SYSTEM_PREFIX_LENGTH: summary["length"],
+    }
 
 
 def _provider_for_model(model: str) -> str:
@@ -606,7 +618,7 @@ def parse_claude_code_session(
             if claude_md_text is None and cwd is not None:
                 claude_md_text = _read_project_claude_md(cwd)
             if claude_md_text:
-                llm_attrs[TjAttributes.SYSTEM_PREFIX_CONTENT] = claude_md_text
+                llm_attrs.update(_system_prefix_attrs(claude_md_text))
         if capture.completions:
             completion_text = _block_text(msg.get("content"))
             if completion_text.strip():

--- a/tokenjam/core/config.py
+++ b/tokenjam/core/config.py
@@ -95,6 +95,17 @@ class StorageConfig:
     # nothing else — every config written before the coupling existed — has its
     # value read AS the span, so nothing about that setup changes.
     retention_days: int | None = None
+    # DuckDB's buffer pool, bounded. Left unset, DuckDB sizes `memory_limit` at
+    # 80% of physical RAM — 19.1 GiB on a 24 GB Mac — and its buffer manager has
+    # no reason to evict below that, so a daemon that should idle near 200 MB
+    # instead grows until the machine is swapping. This is a *ceiling*, not a
+    # reservation: past it DuckDB spills to `temp_directory` rather than
+    # failing, so a small number costs disk I/O on the rare large scan and
+    # nothing the rest of the time. `threads` is capped for the same reason —
+    # each carries its own allocation arenas, and the daemon opens a second
+    # backend for transcript catch-up while the request path is live.
+    memory_limit:   str = "1GB"
+    threads:        int = 4
     # Runtime provenance, never read from or written to TOML: True when `path`
     # came from an explicit `--db` rather than config discovery. The
     # filesystem-reading analyzers scope themselves off it (see
@@ -802,6 +813,8 @@ def _parse(raw: dict) -> TjConfig:
         # would erase that distinction.
         analysis_span=storage_raw.get("analysis_span"),
         retention_days=storage_raw.get("retention_days"),
+        memory_limit=storage_raw.get("memory_limit", StorageConfig.memory_limit),
+        threads=storage_raw.get("threads", StorageConfig.threads),
     )
 
     export_raw = raw.get("export", {})

--- a/tokenjam/core/config.py
+++ b/tokenjam/core/config.py
@@ -104,7 +104,13 @@ class StorageConfig:
     # nothing the rest of the time. `threads` is capped for the same reason —
     # each carries its own allocation arenas, and the daemon opens a second
     # backend for transcript catch-up while the request path is live.
-    memory_limit:   str = "1GB"
+    # 2GB rather than 1GB because 1GB was measured failing here: on a 768k-span
+    # database the daemon OOMed on a request-path aggregate while the startup
+    # transcript catch-up already held the pool ("1.0 GiB/953.6 MiB used" — the
+    # query needed 16 KB more). The ceiling has to fit the request path AND the
+    # catch-up backend that runs beside it, not either alone. Raise it if a scan
+    # ever spills enough to feel slow.
+    memory_limit:   str = "2GB"
     threads:        int = 4
     # Runtime provenance, never read from or written to TOML: True when `path`
     # came from an explicit `--db` rather than config discovery. The

--- a/tokenjam/core/db.py
+++ b/tokenjam/core/db.py
@@ -2609,6 +2609,41 @@ _SESSION_TOTALS_ACCUMULATE = """
 """
 
 
+def _connect_bounded(db_path: str, memory_limit: str, threads: int):
+    """Open `db_path` with an explicit buffer-pool ceiling.
+
+    Every connection to the telemetry database goes through here — `__init__`
+    AND `_reopen`. That matters more than it looks: a bound applied only at
+    startup silently disappears the first time the backend recovers from a
+    fatal error, and the recovered daemon then runs unbounded with no symptom
+    until the machine is swapping. See `StorageConfig.memory_limit` for why the
+    default is small.
+
+    `temp_directory` is what makes the ceiling safe rather than fatal — past the
+    limit DuckDB spills there instead of raising — and it sits beside the
+    database so the spill lands on the volume already allotted to this tool. A
+    value DuckDB rejects must never make the database unopenable, so a bad
+    override degrades to the default rather than propagating.
+    """
+    settings = {
+        "memory_limit": memory_limit or StorageConfig.memory_limit,
+        "threads": str(threads or StorageConfig.threads),
+        "temp_directory": str(Path(db_path).parent / "duckdb_temp"),
+    }
+    try:
+        return duckdb.connect(db_path, config=settings)
+    except duckdb.Error:
+        logger.warning(
+            "storage.memory_limit=%r / storage.threads=%r rejected by DuckDB; "
+            "falling back to %s / %s",
+            memory_limit, threads,
+            StorageConfig.memory_limit, StorageConfig.threads,
+        )
+        settings["memory_limit"] = StorageConfig.memory_limit
+        settings["threads"] = str(StorageConfig.threads)
+        return duckdb.connect(db_path, config=settings)
+
+
 class DuckDBBackend:
     """Concrete DuckDB implementation of StorageBackend."""
 
@@ -2616,7 +2651,9 @@ class DuckDBBackend:
         db_path = Path(config.path).expanduser()
         db_path.parent.mkdir(parents=True, exist_ok=True)
         self._db_path: str | None = str(db_path)
-        self._conn = duckdb.connect(str(db_path))
+        self._memory_limit = config.memory_limit
+        self._threads = config.threads
+        self._conn = _connect_bounded(str(db_path), config.memory_limit, config.threads)
         run_migrations(self._conn)
         self._local = threading.local()
         # Every cursor `conn` has handed out. Recovery must close ALL of them —
@@ -2730,7 +2767,9 @@ class DuckDBBackend:
             return False
         try:
             with self._conn_lock:
-                self._conn = duckdb.connect(self._db_path)
+                self._conn = _connect_bounded(
+                    self._db_path, self._memory_limit, self._threads,
+                )
                 run_migrations(self._conn)
             return self.check_health()
         except Exception as exc:  # noqa: BLE001

--- a/tokenjam/core/db.py
+++ b/tokenjam/core/db.py
@@ -2625,7 +2625,10 @@ def _connect_bounded(db_path: str, memory_limit: str, threads: int):
     value DuckDB rejects must never make the database unopenable, so a bad
     override degrades to the default rather than propagating.
     """
-    settings = {
+    # Annotated because duckdb's `config=` parameter is typed as an invariant
+    # dict over a union: an inferred dict[str, str] is rejected by mypy even
+    # though every value here is a str.
+    settings: dict[str, str | bool | int | float | list[str]] = {
         "memory_limit": memory_limit or StorageConfig.memory_limit,
         "threads": str(threads or StorageConfig.threads),
         "temp_directory": str(Path(db_path).parent / "duckdb_temp"),

--- a/tokenjam/core/ingest.py
+++ b/tokenjam/core/ingest.py
@@ -144,9 +144,16 @@ def strip_captured_content(attributes: dict, capture: CaptureConfig) -> dict:
         stripped[TjAttributes.TOOL_ARG_SIG] = sig
     if not capture.prompts:
         stripped.pop(GenAIAttributes.PROMPT_CONTENT, None)
-        # The recovered system prefix (a project's CLAUDE.md text, stamped by
-        # backfill) is prompt content and rides the same toggle.
+        # The recovered system prefix (derived from a project's CLAUDE.md by
+        # backfill) is prompt content and rides the same toggle. All four keys
+        # go: the legacy text one for spans that still carry it, and the three
+        # compact ones that replaced it — SAMPLE is literal prompt text, and
+        # leaving HASH/LENGTH behind would keep a fingerprint of a file the
+        # user just said not to capture.
         stripped.pop(TjAttributes.SYSTEM_PREFIX_CONTENT, None)
+        stripped.pop(TjAttributes.SYSTEM_PREFIX_HASH, None)
+        stripped.pop(TjAttributes.SYSTEM_PREFIX_SAMPLE, None)
+        stripped.pop(TjAttributes.SYSTEM_PREFIX_LENGTH, None)
         for key in _REQUEST_PARAM_ATTRS:
             stripped.pop(key, None)
     if not capture.completions:

--- a/tokenjam/core/optimize/analyzers/cache_recommend.py
+++ b/tokenjam/core/optimize/analyzers/cache_recommend.py
@@ -13,12 +13,19 @@ Per-provider scope: Anthropic only. Other providers' caching mechanics
 (or lack thereof) differ enough that a v1 recommendation engine would
 mislead. Multi-provider support is a future research project.
 
-The candidate prefix comes from `TjAttributes.SYSTEM_PREFIX_CONTENT` when a
-span carries it, falling back to `GenAIAttributes.PROMPT_CONTENT` otherwise
-(#272). Claude-Code-sourced spans carry the former (the project's CLAUDE.md,
-read straight off disk by the backfill parser) because the latter is the
-human's per-turn message on those spans — a different string every turn,
-so it never repeats verbatim and the prefix-hash below always came up empty.
+The candidate prefix comes from the compact `TjAttributes.SYSTEM_PREFIX_*`
+attributes when a span carries them, from the legacy `SYSTEM_PREFIX_CONTENT` on
+older spans, and from `GenAIAttributes.PROMPT_CONTENT` otherwise (#272).
+Claude-Code-sourced spans carry a system prefix (the project's CLAUDE.md, read
+off disk by the backfill parser) because `PROMPT_CONTENT` is the human's
+per-turn message on those spans — a different string every turn, so it never
+repeats verbatim and the prefix-hash always came up empty.
+
+The prefix is no longer stored as text. It was identical across every span of a
+project, so keeping it whole cost (size x span count) — 4.06 GB of one real
+database to carry 1.84 MB of distinct text. What this analyzer needs from it is
+an identity, a 120-character sample and a length; `core.system_prefix` derives
+all three at capture time.
 
 This analyzer is disabled outright for the `claude-code` persona
 (`runner.PERSONA_DISABLED_ANALYZERS`) — not because this prefix detection
@@ -32,7 +39,6 @@ per-window; see `core.framing.dominant_persona`).
 """
 from __future__ import annotations
 
-import hashlib
 import json
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -41,13 +47,16 @@ from typing import Any
 from tokenjam.core.optimize.registry import register
 from tokenjam.core.optimize.types import AnalyzerContext
 from tokenjam.core.optimize.span_pricing import blended_rates
+from tokenjam.core import system_prefix
 from tokenjam.otel.semconv import GenAIAttributes, TjAttributes
 from tokenjam.core.persona_scope import add_persona_clause
 
 # The first N characters of the prompt are hashed to identify a "prefix
 # signature." Long enough to discriminate, short enough to avoid hashing
 # every call's full payload.
-PREFIX_HASH_BYTES = 2000
+# Re-exported from `core.system_prefix`, which owns the window. Kept as a
+# module name because tests and `estimated_cacheable` below read it.
+PREFIX_HASH_BYTES = system_prefix.HASH_CHARS
 
 # Minimum occurrences of the same prefix before it's worth recommending
 # a cache_control placement. Three calls share a prefix => likely a stable
@@ -135,9 +144,15 @@ def _stringify_prompt(value: Any) -> str:
 
 
 def _prefix_hash(text: str) -> str:
-    """SHA-256 of the first PREFIX_HASH_BYTES chars (UTF-8) of the prompt."""
-    head = text[:PREFIX_HASH_BYTES].encode("utf-8", errors="replace")
-    return hashlib.sha256(head).hexdigest()[:16]
+    """SHA-256 of the first PREFIX_HASH_BYTES chars (UTF-8) of the prompt.
+
+    Delegates to `core.system_prefix` so the hash this analyzer computes for a
+    legacy span and the hash the parser stamped onto a new one are the same
+    function. They used to be two copies of the same three lines; if they ever
+    diverged, one project's spans would split across two candidates and the
+    occurrence counts on both would be wrong with nothing failing.
+    """
+    return system_prefix.prefix_hash(text)
 
 
 def _prefix_cache_control_snippet(
@@ -268,18 +283,34 @@ def run(ctx: AnalyzerContext) -> None:
         # repeats verbatim, so hashing it never found a shared prefix.
         # Raw-API-instrumented spans (no backfill involved) carry no such
         # attribute and fall through to `PROMPT_CONTENT` unchanged.
-        content = attrs.get(TjAttributes.SYSTEM_PREFIX_CONTENT) or attrs.get(
-            GenAIAttributes.PROMPT_CONTENT
-        )
-        if not content:
-            continue
-        text = _stringify_prompt(content)
-        if len(text) < 200:
-            # Skip tiny prompts — no caching opportunity.
-            continue
-        h = _prefix_hash(text)
+        # Three shapes reach this loop, and all three must keep working:
+        #   1. the compact form (hash/sample/length) written since the prefix
+        #      stopped being stored whole,
+        #   2. `SYSTEM_PREFIX_CONTENT`, on every span backfilled before that —
+        #      dropping this branch would make years of history invisible to
+        #      this analyzer the day the change shipped,
+        #   3. no prefix attribute at all -> `PROMPT_CONTENT`.
+        prefix_hash_attr = attrs.get(TjAttributes.SYSTEM_PREFIX_HASH)
+        if prefix_hash_attr:
+            if int(attrs.get(TjAttributes.SYSTEM_PREFIX_LENGTH) or 0) < \
+                    system_prefix.MIN_CACHEABLE_CHARS:
+                continue
+            h = str(prefix_hash_attr)
+            sample = str(attrs.get(TjAttributes.SYSTEM_PREFIX_SAMPLE) or "")
+        else:
+            content = attrs.get(TjAttributes.SYSTEM_PREFIX_CONTENT) or attrs.get(
+                GenAIAttributes.PROMPT_CONTENT
+            )
+            if not content:
+                continue
+            text = _stringify_prompt(content)
+            if len(text) < system_prefix.MIN_CACHEABLE_CHARS:
+                # Skip tiny prompts — no caching opportunity.
+                continue
+            h = _prefix_hash(text)
+            sample = text[:system_prefix.SAMPLE_CHARS]
         entry = prefix_counts.setdefault(h, {
-            "sample": text[:120],
+            "sample": sample,
             "count": 0,
             "tokens_sum": 0,
             "model_counts": {},

--- a/tokenjam/core/system_prefix.py
+++ b/tokenjam/core/system_prefix.py
@@ -1,0 +1,68 @@
+"""What gets stored about a reused system prefix, and what reads it back.
+
+The prefix (a project's ``CLAUDE.md``, resent verbatim on every API call) is
+what ``cache-recommend`` looks for. It used to be stored on the span as the
+whole file, which is the most expensive possible way to hold it: the text is
+identical across every span of a project, so the cost is (size x span count).
+Measured before the fix — 92,514 spans holding ~43 KB each, **4.06 GB** on disk
+to carry **1.84 MB** of distinct text.
+
+The analyzer never needed the text. It needs exactly three answers, and all
+three are derivable at capture time:
+
+===================  =========================================================
+``hash``             identity — which prefix this is, for grouping and counting
+``sample``           the first :data:`SAMPLE_CHARS`, for display only
+``length``           the character count, for the analyzer's own size gate
+===================  =========================================================
+
+Storing those three instead of the text takes ~230 bytes per span rather than
+~43,000, and none of the three loses information the analyzer was using.
+
+**This module is the single source of both halves.** The producer
+(``core.backfill``) and the consumer (``cache_recommend``) previously agreed
+only by coincidence — the analyzer hashed ``text[:PREFIX_HASH_BYTES]`` while
+the parser stored whatever it read off disk. Now both call
+:func:`prefix_hash`, so a change to the window cannot silently reclassify old
+spans into new groups. ``test_hash_window_is_single_sourced`` fails if the
+analyzer stops routing through here.
+"""
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+# The window that DEFINES prefix identity. Two prompts sharing their first
+# HASH_CHARS characters are one cacheable prefix as far as this product is
+# concerned — the number is a claim about how much of a prefix has to match to
+# be worth a cache breakpoint, not an implementation detail.
+HASH_CHARS = 2000
+
+# Kept for display only: enough to recognise which prefix a candidate is,
+# never enough to reconstruct the file.
+SAMPLE_CHARS = 120
+
+# Below this a prompt is too small for caching to pay for itself, so the
+# analyzer skips it. Stored length is compared against this.
+MIN_CACHEABLE_CHARS = 200
+
+
+def prefix_hash(text: str) -> str:
+    """Stable identity for a reused prefix: SHA-256 of its first HASH_CHARS."""
+    head = text[:HASH_CHARS].encode("utf-8", errors="replace")
+    return hashlib.sha256(head).hexdigest()[:16]
+
+
+def summarize(text: str) -> dict[str, Any]:
+    """The compact form stored on a span, or ``{}`` when there is nothing to store.
+
+    Returns bare values rather than attribute keys so the caller decides
+    namespacing; see ``TjAttributes.SYSTEM_PREFIX_*``.
+    """
+    if not text:
+        return {}
+    return {
+        "hash": prefix_hash(text),
+        "sample": text[:SAMPLE_CHARS],
+        "length": len(text),
+    }

--- a/tokenjam/otel/semconv.py
+++ b/tokenjam/otel/semconv.py
@@ -266,6 +266,15 @@ class TjAttributes:
     # carries the one thing that actually IS resent identically call after
     # call. Gated by the same [capture] `prompts` toggle as PROMPT_CONTENT.
     SYSTEM_PREFIX_CONTENT = "tokenjam.system_prefix.content"
+    # How much of that prefix is worth storing. The value is written once per
+    # LLM span but is identical across every span of a project, so its true cost
+    # is (size x span count): on a real machine, 92,514 spans holding ~43 KB
+    # each came to 4.06 GB on disk carrying 1.8 MB of distinct text, which then
+    # had to be paged through DuckDB's buffer pool on every scan of the table.
+    # `cache_recommend` — the only consumer — never reads past
+    # `PREFIX_HASH_BYTES`, so this cap must stay >= that constant;
+    # `test_system_prefix_capture_covers_hash_window` fails if it drifts under.
+    SYSTEM_PREFIX_CAPTURE_CHARS = 2000
 
     # Enforcement-plane self-observation (#223). The proxy emits one span per
     # recorded policy decision under this namespace so the web UI + drift see

--- a/tokenjam/otel/semconv.py
+++ b/tokenjam/otel/semconv.py
@@ -265,16 +265,21 @@ class TjAttributes:
     # for a shared-prefix match (cache-recommend) always came up empty. This
     # carries the one thing that actually IS resent identically call after
     # call. Gated by the same [capture] `prompts` toggle as PROMPT_CONTENT.
+    # LEGACY, read-only. Spans written before the compact form below carry the
+    # prefix text itself. `cache_recommend` still falls back to this key so
+    # existing history keeps working; nothing writes it any more.
     SYSTEM_PREFIX_CONTENT = "tokenjam.system_prefix.content"
-    # How much of that prefix is worth storing. The value is written once per
-    # LLM span but is identical across every span of a project, so its true cost
-    # is (size x span count): on a real machine, 92,514 spans holding ~43 KB
-    # each came to 4.06 GB on disk carrying 1.8 MB of distinct text, which then
-    # had to be paged through DuckDB's buffer pool on every scan of the table.
-    # `cache_recommend` — the only consumer — never reads past
-    # `PREFIX_HASH_BYTES`, so this cap must stay >= that constant;
-    # `test_system_prefix_capture_covers_hash_window` fails if it drifts under.
-    SYSTEM_PREFIX_CAPTURE_CHARS = 2000
+
+    # The compact form, written instead of the text. The value was identical
+    # across every span of a project, so storing it whole cost (size x span
+    # count): 92,514 spans holding ~43 KB each came to 4.06 GB on disk carrying
+    # 1.84 MB of distinct text, all of which had to page through DuckDB's buffer
+    # pool on every scan of the table. These three carry every answer the
+    # analyzer took from the text, in ~230 bytes rather than ~43,000. Derived by
+    # `core.system_prefix`, which is the single source both sides use.
+    SYSTEM_PREFIX_HASH = "tokenjam.system_prefix.hash"
+    SYSTEM_PREFIX_SAMPLE = "tokenjam.system_prefix.sample"
+    SYSTEM_PREFIX_LENGTH = "tokenjam.system_prefix.length"
 
     # Enforcement-plane self-observation (#223). The proxy emits one span per
     # recorded policy decision under this namespace so the web UI + drift see


### PR DESCRIPTION
Found while diagnosing a Mac sitting at 4–6 GB of RAM with 11.4 GB of swap in use. The `tj` daemon was a large part of it and `~/.tj/telemetry.duckdb` had reached 3.7 GB. Two independent causes.

## 1. The whole `CLAUDE.md` was stored on every span

`_read_project_claude_md` captured the project's entire `CLAUDE.md` onto each assistant LLM span. The value is written **per span** but is **identical across every span of a project**, so its real cost is size × span count:

| | |
|---|---|
| Spans carrying it | 92,514 |
| Avg bytes each | 43,832 |
| Total on disk | **4.06 GB** |
| Distinct values | 61 |
| Unique text | **1.84 MB** |
| Amplification | **2207×** |

All of it had to page through DuckDB's buffer pool on every scan of `spans`.

### The fix: store a fingerprint, not the file

`cache_recommend` is the only consumer, and it never read the prefix as text. It uses it exactly three ways:

| Use | Needs |
|---|---|
| `_prefix_hash(text)` | an identity |
| display | `text[:120]` |
| skip gate | `len(text)` |

All three are derivable at capture time. The span now carries those three (~230 bytes) instead of the file (~43,000) — the same real database would hold **~18 MB** where it once held **4.06 GB**.

An intermediate commit here truncated the text to 2000 chars. That cut the worst of it but left the shape of the defect intact: measured on the real database, the truncated form is still **155 MB across 76,962 spans to carry 61 KB of distinct text** — 32 distinct values, a 2505× amplification. The problem was never the size of the value, it was storing a per-project constant per span. Both commits are kept so the reasoning stays on the record.

`core.system_prefix` owns the derivation because the producer and the consumer previously agreed only by coincidence — the parser stored whatever it read off disk while the analyzer hashed `text[:PREFIX_HASH_BYTES]`. Both now route through one function. Divergence there has no symptom: it would silently split one project's spans across two candidates and understate both occurrence counts.

### Existing history keeps working

The legacy `SYSTEM_PREFIX_CONTENT` branch stays as a **read** path. Every span backfilled before this change carries the text, and dropping the fallback would make that history invisible to the analyzer the day the release shipped. `test_legacy_and_compact_spans_land_in_one_candidate` pins that old and new spans describing the same prefix group together — verified by deleting the fallback, which fails it plus one pre-existing persona test.

Capture-off strips all four keys, not just the text one: `SAMPLE` is literal prompt content, and leaving `HASH`/`LENGTH` behind would keep a fingerprint of a file the user just said not to capture.

## 2. DuckDB was given no memory budget

`duckdb.connect()` was called with no config. Left unset, DuckDB sizes `memory_limit` at **80% of physical RAM** — 19.1 GiB on a 24 GB Mac — and its buffer manager has no reason to evict below that, so the daemon grows until the machine swaps.

Both connect sites now route through `_connect_bounded`. That detail is load-bearing: applying the bound only in `__init__` leaves it **silently absent** after `_reopen` recovers from a fatal error, and a recovered daemon running unbounded has no symptom until the machine is already swapping.

The ceiling is **2GB**, measured rather than picked. At 1GB the daemon returned 500s:

```
_duckdb.OutOfMemoryException: failed to allocate data of size 16.0 KiB (1.0 GiB/953.6 MiB used)
  File "tokenjam/core/db.py", line 3828, in get_daily_cost
```

That aggregate runs fine under 1GB in isolation (0.1s on the 768k-span database). What broke it is that `start_catch_up` opens its **own** backend beside the request path, so the pool was already full. Verified separately that same-path connections share one database instance, so the ceiling is 2GB for the process rather than 2GB per backend.

`temp_directory` makes the ceiling a spill point rather than a failure, and an override DuckDB rejects degrades to the default instead of leaving the database unopenable.

## Result

Daemon RSS: **880 MB idle (spiking multi-GB) → 111 MB, settling to 25 MB** once startup catch-up finishes. Endpoints verified serving 200s throughout.

## Tests

`tests/unit` + `tests/synthetic`: **4813 passed**. `ruff check tokenjam/` and `mypy tokenjam/` clean.

Notable additions, each pinning something with no other symptom:

- `test_legacy_and_compact_spans_land_in_one_candidate` — the upgrade must not split a project's history in two.
- `test_hash_window_is_single_sourced` — producer and consumer share one window constant.
- `test_stored_hash_matches_what_the_analyzer_computes_from_text` — identity survives the change of storage.
- `test_two_prefixes_differing_after_the_window_are_one_candidate` — states what the window *means*, so changing it is deliberate.
- `test_capture_off_strips_every_system_prefix_key` — no fingerprint left behind.
- `test_backfill_stores_a_fingerprint_not_the_file` — the defect as a property: a big `CLAUDE.md` must not make a big span.

The two pre-existing backfill tests that asserted the old attribute are **updated, not deleted** — what they guard (a stable per-project signal that is not the per-turn prompt; the lazy-load retry after a record with no `cwd`) is unchanged.

## Two notes

**Existing databases.** This stops the growth; it does not shrink a database that already has the blobs. DuckDB never returns free blocks to the OS, so reclaiming needs the stored values reduced in place and then a `COPY FROM DATABASE` rewrite into a fresh file. Doing that took a real 3.94 GB database to 0.75 GB with all 767,128 spans and 7,167 sessions preserved.

**Pre-existing lint.** The `lint` job also runs `mypy tokenjam/`, which reports an unrelated pre-existing error in the `ingest_secret` patcher (`config.py`, `m.group(1) + f'"{secret}"'`) on some mypy versions. Left alone rather than folded into a storage PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
