### PR TITLE
fix: gate npm wrapper publish on PyPI visibility, fail closed on unresolved pin

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -85,6 +85,48 @@ jobs:
         working-directory: npm-wrapper
         run: npm version "${GITHUB_REF_NAME#v}" --no-git-tag-version --allow-same-version
 
+      # Both publish workflows fire off the same `release: published` event with
+      # no ordering dependency between them, and this job does far less work
+      # before its own publish step than the PyPI job does (which runs the full
+      # test suite first) — so without a gate here, the npm wrapper routinely
+      # goes live first. bin/tj.js pins `uvx --from tokenjam==<own version>`,
+      # and uv/pipx cache a resolved tool env against that exact spec string
+      # forever, so a user who runs `npx tokenjam` inside that window gets a
+      # PERMANENTLY stale cached environment — not a transient glitch, a
+      # sticky one. Block the wrapper publish until the exact version this
+      # release cuts is actually resolvable on PyPI, and fail the job (not
+      # just warn) if it never shows up in time, rather than publish ahead of
+      # the artifact it pins to.
+      #
+      # Uses the per-version JSON endpoint (pypi.org/pypi/<pkg>/<version>/json)
+      # rather than the package-level one: it 404s for a version that isn't
+      # live yet and 200s once it is, with no releases-list parsing needed.
+      # 200 is the ONLY success signal — no non-zero-but-ok tolerance, since
+      # the whole point of this probe is telling "resolved" from "not yet".
+      - name: Wait for matching PyPI release to be visible
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
+          URL="https://pypi.org/pypi/tokenjam/${VERSION}/json"
+          TIMEOUT_SECONDS=1800   # 30min: full pytest suite + build + upload + CDN/JSON-API propagation lag
+          INTERVAL_SECONDS=15
+          ELAPSED=0
+
+          echo "Waiting for tokenjam==${VERSION} to become visible at ${URL}"
+          while [ "$ELAPSED" -lt "$TIMEOUT_SECONDS" ]; do
+            STATUS="$(curl -s -o /dev/null -w '%{http_code}' "$URL")"
+            if [ "$STATUS" = "200" ]; then
+              echo "tokenjam==${VERSION} is live on PyPI after ${ELAPSED}s (http ${STATUS})"
+              exit 0
+            fi
+            echo "not yet visible after ${ELAPSED}s (http ${STATUS})"
+            sleep "$INTERVAL_SECONDS"
+            ELAPSED=$((ELAPSED + INTERVAL_SECONDS))
+          done
+
+          echo "::error::tokenjam==${VERSION} never appeared on PyPI within ${TIMEOUT_SECONDS}s. Refusing to publish the npm wrapper ahead of the PyPI artifact it pins to (see bin/tj.js version-pinning comment) — check the publish-pypi.yml run for this release."
+          exit 1
+
       - name: Publish
         working-directory: npm-wrapper
         run: npm publish --access public

--- a/npm-wrapper/bin/tj.js
+++ b/npm-wrapper/bin/tj.js
@@ -31,9 +31,19 @@
  * tokenjam==<version>` / `--spec tokenjam==<version>` to this wrapper's OWN
  * version (kept in sync with the release tag by publish-npm.yml's `npm
  * version ${GITHUB_REF_NAME#v}` step) forces the resolver past that shortcut,
- * so `npx tokenjam` always runs the release it shipped with. If the pinned
- * spec can't be resolved yet (this wrapper published slightly ahead of PyPI
- * propagation), we fall back to the unpinned form rather than fail outright.
+ * so `npx tokenjam` always runs the release it shipped with.
+ *
+ * Fail-closed on an unresolved pin: publish-npm.yml's wrapper job now blocks
+ * on the matching PyPI release actually being visible before it publishes
+ * this wrapper, so "pinned spec doesn't resolve" should no longer happen in
+ * the ordinary run. Silently falling back to the unpinned form here traded a
+ * loud, correct, RETRYABLE failure for a silent PERMANENT one: uv/pipx cache
+ * whatever the unpinned spec resolves to and never re-resolve on their own,
+ * so one unlucky run during any remaining propagation gap left a stale
+ * version cached forever — surfacing as "0.6.2 shipped a palette rework but
+ * npx still shows the old colors" with no obvious cause. A resolution
+ * failure is now reported and the next runner (or an already-installed PATH
+ * `tj`) is tried instead — never a silent unpinned run.
  *
  * Staleness note: pinning only fixes what THIS wrapper runs. A bare `tj`
  * invoked directly (no `npx`) still runs whatever was separately installed
@@ -247,11 +257,28 @@ function main() {
     : { ...process.env, TJ_NPX_ZERO_INSTALL_REPORT: "1" };
 
   const version = ownVersion();
+  let sawUnresolvedPin = false;
 
   for (const { bin, pinnedPrefix, prefix } of runners(version)) {
     if (!has(bin)) continue;
-    const args =
-      pinnedPrefix && resolves(bin, pinnedPrefix) ? pinnedPrefix : prefix;
+
+    let args;
+    if (pinnedPrefix) {
+      if (!resolves(bin, pinnedPrefix)) {
+        // Fail closed: never silently drop to the unpinned spec (see the
+        // version-pinning comment at the top of this file for why). Report
+        // and move on to the next runner instead.
+        sawUnresolvedPin = true;
+        process.stderr.write(
+          `Note: ${bin} can't resolve tokenjam==${version} yet — skipping it rather than running an unpinned (potentially stale-cached) version.\n`
+        );
+        continue;
+      }
+      args = pinnedPrefix;
+    } else {
+      args = prefix;
+    }
+
     const result = spawnSync(bin, [...args, ...passthrough], {
       stdio: "inherit",
       env: childEnv,
@@ -259,6 +286,17 @@ function main() {
     if (result.error) continue; // try the next runner on spawn failure
     warnIfShadowedByStaleInstall(version);
     process.exit(result.status === null ? 1 : result.status);
+  }
+
+  if (sawUnresolvedPin) {
+    process.stderr.write(
+      "\n" +
+        `tj (TokenJam): couldn't resolve tokenjam==${version} on PyPI through uv/pipx, and no already-installed 'tj' was found on PATH.\n` +
+        "This should be transient — PyPI's CDN can lag briefly right after a release. Wait a minute and re-run `npx tokenjam`.\n" +
+        "If it persists, check https://pypi.org/project/tokenjam/#history for the release, or install an unpinned copy yourself:\n" +
+        "  uvx --from tokenjam tj   /   pipx run --spec tokenjam tj\n\n"
+    );
+    process.exit(1);
   }
 
   process.stderr.write(


### PR DESCRIPTION
## Problem

`publish-npm.yml` and `publish-pypi.yml` both fire off the same `release: published` event with no ordering dependency between them. The PyPI job runs the full pytest suite before building/publishing; the npm wrapper job only runs a syntax check, so it routinely goes live first.

`npm-wrapper/bin/tj.js` pins `uvx --from tokenjam==<own version>` (and the pipx equivalent), but per its own comment it fell back to the *unpinned* `--from tokenjam` when the pinned spec hadn't propagated to PyPI yet. `uv`/`pipx` cache a resolved tool environment against the exact spec string and never re-resolve it on their own — so that fallback converts a brief publish-ordering race into a **permanently stale cached environment** on the user's machine.

This was confirmed empirically after a real release: the PyPI wheel was verified to contain the intended change, but a fresh `npx tokenjam` run still rendered the old behavior. `tj onboard` printed its own shadow warning about a stale `~/.cache/uv/...` env shadowing the newly installed one, and `uv tool upgrade tokenjam` was what finally surfaced the fix.

## Fix

1. **`publish-npm.yml`** — added a "Wait for matching PyPI release to be visible" step to the wrapper-publish job, right before `npm publish`. It polls the per-version PyPI JSON endpoint (`pypi.org/pypi/tokenjam/<version>/json`) every 15s for up to 30 minutes, and treats HTTP 200 as the only success signal (404 = not yet visible). If the version never appears in time, the step fails the job — the wrapper is never published ahead of the PyPI artifact it pins to.

2. **`npm-wrapper/bin/tj.js`** — changed the runner-resolution loop to fail closed instead of silently falling back to an unpinned spec. If a runner (uvx/pipx) can't resolve the pinned version, it's skipped with a printed note and the next runner (or an already-installed `tj` on PATH) is tried. If nothing resolves, the script exits non-zero with an actionable message telling the user to retry shortly or install an unpinned copy manually. The unpinned fallback existed specifically to paper over the publish race that step 1 now closes, so keeping it silent no longer buys anything — it only trades a loud, retryable failure for what was previously a silent, permanent one.

## Verification

Ran the poll logic standalone against the real PyPI JSON API (not via a release — PyPI versions can't be reused, so no release was cut for this PR):

```
=== Case 1: existing version 0.6.2, short timeout, expect success fast ===
Polling https://pypi.org/pypi/tokenjam/0.6.2/json (timeout 15s, interval 5s)
RESOLVED after 0s (http 200)
PASS: resolved as expected

=== Case 2: nonexistent version 999.0.0, short timeout, expect failure ===
Polling https://pypi.org/pypi/tokenjam/999.0.0/json (timeout 15s, interval 5s)
not yet visible after 0s (http 404)
not yet visible after 5s (http 404)
not yet visible after 10s (http 404)
TIMEOUT after 15s: tokenjam==999.0.0 never appeared on PyPI
PASS: correctly timed out / failed as expected
```

This confirms the gate correctly resolves for a live version and correctly fails (not a false-pass) for one that will never appear — the exit-code trap called out in the brief (tolerating a non-zero status as "maybe resolved") does not apply here since the probe is a plain HTTP status check with 200 as the sole success value.

Also ran `node -c npm-wrapper/bin/tj.js` (syntax OK) and validated the workflow YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`). `actionlint` wasn't available in this environment, so it wasn't run.

## Not done

- Did not cut a release to test the gate end-to-end in CI (version numbers on PyPI can't be reused, so this would be irreversible).
- No automated tests added for `tj.js` — the file has no existing test harness (no Python in the JS lane), consistent with how the wrapper is already covered (a syntax check only).
