### PR TITLE
Fix UTC day bucketing and a lying cast in the API read path

### DIFF
--- a/tests/integration/test_db.py
+++ b/tests/integration/test_db.py
@@ -1,7 +1,7 @@
 """Integration tests for the database layer."""
 from __future__ import annotations
 
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -684,6 +684,33 @@ def test_get_cost_summary_tenant_equality_filter(db):
     assert len(results) == 1
     assert abs(results[0].cost_usd - 3.0) < 0.001
     assert results[0].model == "claude-haiku-4-5"
+
+
+@pytest.mark.parametrize("db_timezone", ["UTC", "Asia/Kolkata", "America/Los_Angeles"])
+def test_get_cost_summary_by_day_buckets_on_the_utc_date(db, db_timezone):
+    """``--group-by day`` must bucket by the UTC date, not the session's local
+    timezone.
+
+    A bare ``CAST(start_time AS DATE)`` resolves a TIMESTAMPTZ through the
+    connection's local timezone before truncating, so a span logged late in
+    the UTC day gets stamped with tomorrow's date on any machine running
+    ahead of UTC (e.g. Asia/Kolkata, +05:30) — the CLI's per-day total would
+    then disagree with anything computed on a UTC basis.
+    """
+    db.conn.execute(f"SET TimeZone='{db_timezone}'")
+    _insert_agent(db)
+    session = make_session()
+    db.upsert_session(session)
+
+    late_utc = datetime(2026, 3, 14, 23, 30, tzinfo=timezone.utc)
+    db.insert_span(make_llm_span(
+        model="claude-haiku-4-5", cost_usd=5.0,
+        session_id=session.session_id, start_time=late_utc,
+    ))
+
+    results = db.get_cost_summary(CostFilters(group_by="day"))
+    assert len(results) == 1
+    assert results[0].group == "2026-03-14"
 
 
 def test_get_cost_summary_returns_empty_when_dimension_never_set(db):

--- a/tests/unit/test_api_backend_span_deserialize.py
+++ b/tests/unit/test_api_backend_span_deserialize.py
@@ -1,0 +1,57 @@
+"""``_dict_to_span`` / ``get_traces`` reconstruct NormalizedSpan/TraceRecord from
+the HTTP-API's JSON, which is the ApiBackend read path used when `tj serve`
+holds the DuckDB write lock.
+
+Both `NormalizedSpan.start_time` and `TraceRecord.start_time` are declared
+non-Optional (models.py) because ingest already rejects any record with no
+observed time rather than substituting a default or leaving it unset. A
+`cast(datetime, ... or None)` here used to silently smuggle a `None` past that
+contract when the wire payload was missing `start_time` — which suppressed the
+exact signal that would have caught unguarded downstream dereferences
+(`core/cost.py`, the cache-efficacy and model-downgrade analyzers). These
+tests pin the replacement contract: a genuinely present `start_time` still
+round-trips, and a missing one now raises instead of laundering a `None`
+through as if it were a `datetime`.
+"""
+from __future__ import annotations
+
+import pytest
+
+from tokenjam.core.api_backend import _dict_to_span, _require_start_time
+
+
+def _span_dict(**overrides):
+    d = {
+        "span_id": "sp-1",
+        "trace_id": "tr-1",
+        "name": "llm.completion",
+        "kind": "internal",
+        "status_code": "ok",
+        "start_time": "2026-03-14T12:00:00+00:00",
+    }
+    d.update(overrides)
+    return d
+
+
+def test_dict_to_span_parses_a_present_start_time():
+    span = _dict_to_span(_span_dict())
+    assert span.start_time.isoformat() == "2026-03-14T12:00:00+00:00"
+
+
+def test_dict_to_span_raises_when_start_time_is_missing():
+    """A malformed/incomplete API response must fail loudly, not hand a
+    `None` to a field the type system promises is always a real `datetime`."""
+    with pytest.raises(ValueError, match="start_time"):
+        _dict_to_span(_span_dict(start_time=None))
+
+
+def test_dict_to_span_raises_when_start_time_key_is_absent():
+    d = _span_dict()
+    del d["start_time"]
+    with pytest.raises(ValueError, match="start_time"):
+        _dict_to_span(d)
+
+
+def test_require_start_time_identifies_the_offending_record():
+    with pytest.raises(ValueError, match="sp-1"):
+        _require_start_time({"span_id": "sp-1", "start_time": None})

--- a/tests/unit/test_optimize.py
+++ b/tests/unit/test_optimize.py
@@ -1,7 +1,7 @@
 """Unit tests for the tj optimize analyzers."""
 from __future__ import annotations
 
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -78,6 +78,29 @@ def test_summarize_window_counts_and_costs(db):
     assert s.sessions == 2
     assert s.total_tokens == 1000 + 200 + 50_000 + 2_000
     assert abs(s.total_cost_usd - (0.030 + 1.500)) < 1e-6
+
+
+@pytest.mark.parametrize("db_timezone", ["UTC", "Asia/Kolkata", "America/Los_Angeles"])
+def test_summarize_window_active_days_buckets_on_the_utc_date(db, db_timezone):
+    """``active_days`` feeds every per-day extrapolation in the optimize
+    report, so it must count distinct UTC dates, not local ones.
+
+    A bare ``CAST(start_time AS DATE)`` resolves a TIMESTAMPTZ through the
+    connection's local timezone before truncating. Two spans that straddle
+    UTC midnight (one at 23:30 UTC, one 1h later at 00:30 UTC the next day —
+    genuinely 2 distinct UTC dates) both land on the SAME local date once
+    shifted by a several-hour offset in either direction, so a buggy bucket
+    collapses them to one day and understates ``active_days``.
+    """
+    db.conn.execute(f"SET TimeZone='{db_timezone}'")
+    day1_2330 = datetime(2026, 3, 14, 23, 30, tzinfo=timezone.utc)
+    day2_0030 = datetime(2026, 3, 15, 0, 30, tzinfo=timezone.utc)
+    _insert_small_opus_session(db, start_time=day1_2330, session_id="a")
+    _insert_small_opus_session(db, start_time=day2_0030, session_id="b")
+    since = day1_2330 - timedelta(hours=2)
+    until = day2_0030 + timedelta(hours=2)
+    s = summarize_window(db.conn, since, until)
+    assert s.active_days == 2
 
 
 def test_summarize_window_total_includes_cache_read_tokens(db):

--- a/tokenjam/core/api_backend.py
+++ b/tokenjam/core/api_backend.py
@@ -6,7 +6,7 @@ queries through the REST API.
 from __future__ import annotations
 
 from datetime import date, datetime, timedelta, timezone
-from typing import Any, cast
+from typing import Any
 
 import httpx
 
@@ -112,14 +112,14 @@ class ApiBackend:
             params["span_name"] = filters.span_name
         data = self._get("/api/v1/traces", params)
         return [
+            # `TraceRecord.start_time` is non-Optional (models.py) for the same
+            # reason `NormalizedSpan.start_time` is — see the guard in
+            # `_dict_to_span` below; the same lying `cast()` used to sit here.
             TraceRecord(
                 trace_id=t["trace_id"],
                 agent_id=t["agent_id"],
                 name=t["name"],
-                start_time=cast(
-                    datetime,
-                    datetime.fromisoformat(t["start_time"]) if t.get("start_time") else None,
-                ),
+                start_time=_require_start_time(t),
                 duration_ms=t.get("duration_ms"),
                 cost_usd=t.get("cost_usd"),
                 status_code=t.get("status_code", "ok"),
@@ -554,6 +554,25 @@ class ApiBackend:
         self.client.close()
 
 
+def _require_start_time(d: dict) -> datetime:
+    """Parse a wire record's ``start_time``, or fail loudly if it's missing.
+
+    ``NormalizedSpan.start_time`` and ``TraceRecord.start_time`` are both
+    non-Optional by design (models.py): ingest already rejects any span with
+    no observed time rather than substituting a default, so a record the
+    daemon serialized always carries a real ``start_time``. A missing or
+    unparseable value here means the wire response itself is malformed, not
+    that the field is legitimately absent — fail loudly instead of passing a
+    `None` off as a `datetime` (a `cast()` used to paper over exactly that,
+    silently disabling the type checker for every downstream consumer that
+    dereferences `start_time` unguarded).
+    """
+    if not d.get("start_time"):
+        ident = d.get("span_id") or d.get("trace_id")
+        raise ValueError(f"record {ident!r} has no start_time in API response")
+    return datetime.fromisoformat(d["start_time"])
+
+
 def _dict_to_span(d: dict) -> NormalizedSpan:
     return NormalizedSpan(
         span_id=d["span_id"],
@@ -561,10 +580,7 @@ def _dict_to_span(d: dict) -> NormalizedSpan:
         name=d["name"],
         kind=SpanKind(d.get("kind", "internal")),
         status_code=SpanStatus(d.get("status_code", "ok")),
-        start_time=cast(
-            datetime,
-            datetime.fromisoformat(d["start_time"]) if d.get("start_time") else None,
-        ),
+        start_time=_require_start_time(d),
         parent_span_id=d.get("parent_span_id"),
         session_id=d.get("session_id"),
         agent_id=d.get("agent_id"),

--- a/tokenjam/core/db.py
+++ b/tokenjam/core/db.py
@@ -3601,7 +3601,7 @@ class DuckDBBackend:
         # columns on `spans` (see migration 17).
         attribution_dims = ("tenant", "feature", "environment", "prompt_version")
         group_col_map = {
-            "day": "CAST(start_time AS DATE)",
+            "day": "CAST(start_time AT TIME ZONE 'UTC' AS DATE)",
             "agent": "agent_id",
             "model": "model",
             "tool": "tool_name",
@@ -3610,7 +3610,9 @@ class DuckDBBackend:
             "environment": "environment",
             "prompt_version": "prompt_template_version",
         }
-        group_expr = group_col_map.get(filters.group_by, "CAST(start_time AS DATE)")
+        group_expr = group_col_map.get(
+            filters.group_by, "CAST(start_time AT TIME ZONE 'UTC' AS DATE)"
+        )
 
         # gen_ai.tool.call spans are separate rows from the LLM completion
         # spans that carry model/cost/tokens (otel/otlp_parsing.py) — a span

--- a/tokenjam/core/optimize/runner.py
+++ b/tokenjam/core/optimize/runner.py
@@ -274,7 +274,7 @@ def summarize_window(
     row = conn.execute(
         f"SELECT COUNT(*) AS spans, "
         f"COUNT(DISTINCT session_id) AS sessions, "
-        f"COUNT(DISTINCT CAST(start_time AS DATE)) AS active_days, "
+        f"COUNT(DISTINCT CAST(start_time AT TIME ZONE 'UTC' AS DATE)) AS active_days, "
         f"COALESCE(SUM(COALESCE(input_tokens,0) + COALESCE(output_tokens,0) + COALESCE(cache_tokens,0) + COALESCE(cache_write_tokens,0)), 0) AS tokens, "
         f"COALESCE(SUM(cost_usd), 0.0) AS cost "
         f"FROM spans WHERE {where}",


### PR DESCRIPTION
## Summary

Two timestamp-correctness fixes, both outside the ingest path:

1. **UTC day bucketing.** Three sites used a bare `CAST(start_time AS DATE)` on the `TIMESTAMPTZ` column: `get_cost_summary`'s `day` grouping (and its default fallback for an unrecognised `group_by`), and the optimize report's `active_days` count. A bare cast resolves through the session's local timezone before truncating, so on a machine running ahead of UTC, spans logged late in the UTC day get stamped with tomorrow's date. That means `tj cost --group-by day` silently disagrees with any UTC-based figure elsewhere, and `active_days` (which every per-day extrapolation in the optimize report divides by) is off by one near local midnight. Fixed by switching to `CAST(start_time AT TIME ZONE 'UTC' AS DATE)`, matching the convention already used elsewhere in the codebase (`core/data_span.py`, `api/routes/analytics.py`, `api/routes/cost.py`).

2. **A `cast()` in the HTTP-API fallback backend that lied to the type checker.** `ApiBackend._dict_to_span` (used when `tj serve` holds the DuckDB write lock) built a `NormalizedSpan` with `start_time=cast(datetime, ... or None)`. `NormalizedSpan.start_time` (and `TraceRecord.start_time`, which had the identical pattern in `get_traces`) is declared non-Optional by design — the header comment on the field says ingest already rejects any span with no observed time rather than substituting a default. The `cast()` didn't convert anything; it just told the type checker to stop looking while a `None` could flow through, leaving every downstream consumer of an HTTP-fallback span unguarded.

   **Decision:** a `start_time` is required here, not optional. A span the daemon serializes always has a real `start_time` (ingest enforces it), so a missing/unparseable value in the wire payload means the response itself is malformed, not that the field is legitimately absent. I raise a `ValueError` naming the offending record instead of casting a `None` past the checker, and factored the shared logic into `_require_start_time()` since `get_traces` had the exact same bug for `TraceRecord`.

## Tests

- `tests/integration/test_db.py::test_get_cost_summary_by_day_buckets_on_the_utc_date` — parametrized over UTC/Asia-Kolkata/America-Los_Angeles session timezones.
- `tests/unit/test_optimize.py::test_summarize_window_active_days_buckets_on_the_utc_date` — same parametrization, two spans straddling UTC midnight.
- `tests/unit/test_api_backend_span_deserialize.py` — new file covering the present/missing/absent-key `start_time` contract for `_dict_to_span` and `_require_start_time`.

I confirmed both new day-bucketing tests fail against the pre-fix bare `CAST(... AS DATE)` (reverted each site locally, ran red, restored, ran green) before finalizing.

## CI

`ruff check` and `mypy` pass on all touched files. Ran the touched test files plus the broader db/optimize/mcp/proxy/storage-parity suites locally (183 passed); did not run the full suite (that's what remote CI is for).

## Deliberately not done

- Did not widen the sweep beyond the three named sites plus the one `get_traces` cast — a full-repo grep for `CAST(... AS DATE)` on timestamp columns turned up no other bare occurrences; everything else already used the `AT TIME ZONE 'UTC'` form.
