### PR TITLE
Three silent-failure fixes: launchd registration and ingestion staleness, npm/PyPI publish race, UTC day bucketing

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -85,6 +85,48 @@ jobs:
         working-directory: npm-wrapper
         run: npm version "${GITHUB_REF_NAME#v}" --no-git-tag-version --allow-same-version
 
+      # Both publish workflows fire off the same `release: published` event with
+      # no ordering dependency between them, and this job does far less work
+      # before its own publish step than the PyPI job does (which runs the full
+      # test suite first) — so without a gate here, the npm wrapper routinely
+      # goes live first. bin/tj.js pins `uvx --from tokenjam==<own version>`,
+      # and uv/pipx cache a resolved tool env against that exact spec string
+      # forever, so a user who runs `npx tokenjam` inside that window gets a
+      # PERMANENTLY stale cached environment — not a transient glitch, a
+      # sticky one. Block the wrapper publish until the exact version this
+      # release cuts is actually resolvable on PyPI, and fail the job (not
+      # just warn) if it never shows up in time, rather than publish ahead of
+      # the artifact it pins to.
+      #
+      # Uses the per-version JSON endpoint (pypi.org/pypi/<pkg>/<version>/json)
+      # rather than the package-level one: it 404s for a version that isn't
+      # live yet and 200s once it is, with no releases-list parsing needed.
+      # 200 is the ONLY success signal — no non-zero-but-ok tolerance, since
+      # the whole point of this probe is telling "resolved" from "not yet".
+      - name: Wait for matching PyPI release to be visible
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
+          URL="https://pypi.org/pypi/tokenjam/${VERSION}/json"
+          TIMEOUT_SECONDS=1800   # 30min: full pytest suite + build + upload + CDN/JSON-API propagation lag
+          INTERVAL_SECONDS=15
+          ELAPSED=0
+
+          echo "Waiting for tokenjam==${VERSION} to become visible at ${URL}"
+          while [ "$ELAPSED" -lt "$TIMEOUT_SECONDS" ]; do
+            STATUS="$(curl -s -o /dev/null -w '%{http_code}' "$URL")"
+            if [ "$STATUS" = "200" ]; then
+              echo "tokenjam==${VERSION} is live on PyPI after ${ELAPSED}s (http ${STATUS})"
+              exit 0
+            fi
+            echo "not yet visible after ${ELAPSED}s (http ${STATUS})"
+            sleep "$INTERVAL_SECONDS"
+            ELAPSED=$((ELAPSED + INTERVAL_SECONDS))
+          done
+
+          echo "::error::tokenjam==${VERSION} never appeared on PyPI within ${TIMEOUT_SECONDS}s. Refusing to publish the npm wrapper ahead of the PyPI artifact it pins to (see bin/tj.js version-pinning comment) — check the publish-pypi.yml run for this release."
+          exit 1
+
       - name: Publish
         working-directory: npm-wrapper
         run: npm publish --access public

--- a/npm-wrapper/bin/tj.js
+++ b/npm-wrapper/bin/tj.js
@@ -54,6 +54,7 @@
 "use strict";
 
 const { spawnSync } = require("child_process");
+const fs = require("fs");
 const path = require("path");
 
 // PyPI package name vs. command name differ (`tokenjam` ships the `tj` script),
@@ -110,6 +111,43 @@ function runners(version) {
 function resolves(bin, args) {
   const probe = spawnSync(bin, [...args, "--version"], { stdio: "ignore" });
   return probe.status === 0;
+}
+
+// Resolve `bin` to an absolute path the way the OS would launch it, without
+// spawning it — a plain PATH walk, no shell involved.
+function resolveOnPath(bin) {
+  const dirs = (process.env.PATH || "").split(path.delimiter);
+  const exts =
+    process.platform === "win32"
+      ? (process.env.PATHEXT || ".EXE;.CMD;.BAT").split(";")
+      : [""];
+  for (const dir of dirs) {
+    if (!dir) continue;
+    for (const ext of exts) {
+      const candidate = path.join(dir, bin + ext);
+      try {
+        fs.accessSync(candidate, fs.constants.X_OK);
+        return candidate;
+      } catch {
+        // not here, keep looking
+      }
+    }
+  }
+  return null;
+}
+
+// True when `candidatePath` resolves (through symlinks) to this very file.
+// `npx` symlinks this package's own `tj`/`tokenjam` bin into a temp bin dir
+// and puts that dir on PATH, so a naive "is tj on PATH" probe finds
+// ourselves — re-spawning that would recurse into this same wrapper forever
+// instead of ever reaching a real, separately-installed CLI.
+function isOwnShim(candidatePath) {
+  if (!candidatePath) return false;
+  try {
+    return fs.realpathSync(candidatePath) === fs.realpathSync(__filename);
+  } catch {
+    return false; // couldn't stat either side — don't claim a match
+  }
 }
 
 // --- stale shadowing install detection ------------------------------------
@@ -260,7 +298,15 @@ function main() {
   let sawUnresolvedPin = false;
 
   for (const { bin, pinnedPrefix, prefix } of runners(version)) {
-    if (!has(bin)) continue;
+    if (bin === COMMAND) {
+      // The installed-CLI fallback: only real if it resolves to something
+      // OTHER than this wrapper (see isOwnShim above). Under npx, `has(bin)`
+      // alone would find our own re-exec'd shim and spawn it recursively.
+      const resolved = resolveOnPath(bin);
+      if (!resolved || isOwnShim(resolved)) continue;
+    } else if (!has(bin)) {
+      continue;
+    }
 
     let args;
     if (pinnedPrefix) {

--- a/npm-wrapper/bin/tj.js
+++ b/npm-wrapper/bin/tj.js
@@ -31,9 +31,19 @@
  * tokenjam==<version>` / `--spec tokenjam==<version>` to this wrapper's OWN
  * version (kept in sync with the release tag by publish-npm.yml's `npm
  * version ${GITHUB_REF_NAME#v}` step) forces the resolver past that shortcut,
- * so `npx tokenjam` always runs the release it shipped with. If the pinned
- * spec can't be resolved yet (this wrapper published slightly ahead of PyPI
- * propagation), we fall back to the unpinned form rather than fail outright.
+ * so `npx tokenjam` always runs the release it shipped with.
+ *
+ * Fail-closed on an unresolved pin: publish-npm.yml's wrapper job now blocks
+ * on the matching PyPI release actually being visible before it publishes
+ * this wrapper, so "pinned spec doesn't resolve" should no longer happen in
+ * the ordinary run. Silently falling back to the unpinned form here traded a
+ * loud, correct, RETRYABLE failure for a silent PERMANENT one: uv/pipx cache
+ * whatever the unpinned spec resolves to and never re-resolve on their own,
+ * so one unlucky run during any remaining propagation gap left a stale
+ * version cached forever — surfacing as "0.6.2 shipped a palette rework but
+ * npx still shows the old colors" with no obvious cause. A resolution
+ * failure is now reported and the next runner (or an already-installed PATH
+ * `tj`) is tried instead — never a silent unpinned run.
  *
  * Staleness note: pinning only fixes what THIS wrapper runs. A bare `tj`
  * invoked directly (no `npx`) still runs whatever was separately installed
@@ -247,11 +257,28 @@ function main() {
     : { ...process.env, TJ_NPX_ZERO_INSTALL_REPORT: "1" };
 
   const version = ownVersion();
+  let sawUnresolvedPin = false;
 
   for (const { bin, pinnedPrefix, prefix } of runners(version)) {
     if (!has(bin)) continue;
-    const args =
-      pinnedPrefix && resolves(bin, pinnedPrefix) ? pinnedPrefix : prefix;
+
+    let args;
+    if (pinnedPrefix) {
+      if (!resolves(bin, pinnedPrefix)) {
+        // Fail closed: never silently drop to the unpinned spec (see the
+        // version-pinning comment at the top of this file for why). Report
+        // and move on to the next runner instead.
+        sawUnresolvedPin = true;
+        process.stderr.write(
+          `Note: ${bin} can't resolve tokenjam==${version} yet — skipping it rather than running an unpinned (potentially stale-cached) version.\n`
+        );
+        continue;
+      }
+      args = pinnedPrefix;
+    } else {
+      args = prefix;
+    }
+
     const result = spawnSync(bin, [...args, ...passthrough], {
       stdio: "inherit",
       env: childEnv,
@@ -259,6 +286,17 @@ function main() {
     if (result.error) continue; // try the next runner on spawn failure
     warnIfShadowedByStaleInstall(version);
     process.exit(result.status === null ? 1 : result.status);
+  }
+
+  if (sawUnresolvedPin) {
+    process.stderr.write(
+      "\n" +
+        `tj (TokenJam): couldn't resolve tokenjam==${version} on PyPI through uv/pipx, and no already-installed 'tj' was found on PATH.\n` +
+        "This should be transient — PyPI's CDN can lag briefly right after a release. Wait a minute and re-run `npx tokenjam`.\n" +
+        "If it persists, check https://pypi.org/project/tokenjam/#history for the release, or install an unpinned copy yourself:\n" +
+        "  uvx --from tokenjam tj   /   pipx run --spec tokenjam tj\n\n"
+    );
+    process.exit(1);
   }
 
   process.stderr.write(

--- a/tests/integration/test_db.py
+++ b/tests/integration/test_db.py
@@ -1,7 +1,7 @@
 """Integration tests for the database layer."""
 from __future__ import annotations
 
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -684,6 +684,33 @@ def test_get_cost_summary_tenant_equality_filter(db):
     assert len(results) == 1
     assert abs(results[0].cost_usd - 3.0) < 0.001
     assert results[0].model == "claude-haiku-4-5"
+
+
+@pytest.mark.parametrize("db_timezone", ["UTC", "Asia/Kolkata", "America/Los_Angeles"])
+def test_get_cost_summary_by_day_buckets_on_the_utc_date(db, db_timezone):
+    """``--group-by day`` must bucket by the UTC date, not the session's local
+    timezone.
+
+    A bare ``CAST(start_time AS DATE)`` resolves a TIMESTAMPTZ through the
+    connection's local timezone before truncating, so a span logged late in
+    the UTC day gets stamped with tomorrow's date on any machine running
+    ahead of UTC (e.g. Asia/Kolkata, +05:30) — the CLI's per-day total would
+    then disagree with anything computed on a UTC basis.
+    """
+    db.conn.execute(f"SET TimeZone='{db_timezone}'")
+    _insert_agent(db)
+    session = make_session()
+    db.upsert_session(session)
+
+    late_utc = datetime(2026, 3, 14, 23, 30, tzinfo=timezone.utc)
+    db.insert_span(make_llm_span(
+        model="claude-haiku-4-5", cost_usd=5.0,
+        session_id=session.session_id, start_time=late_utc,
+    ))
+
+    results = db.get_cost_summary(CostFilters(group_by="day"))
+    assert len(results) == 1
+    assert results[0].group == "2026-03-14"
 
 
 def test_get_cost_summary_returns_empty_when_dimension_never_set(db):

--- a/tests/unit/test_api_backend_span_deserialize.py
+++ b/tests/unit/test_api_backend_span_deserialize.py
@@ -1,0 +1,57 @@
+"""``_dict_to_span`` / ``get_traces`` reconstruct NormalizedSpan/TraceRecord from
+the HTTP-API's JSON, which is the ApiBackend read path used when `tj serve`
+holds the DuckDB write lock.
+
+Both `NormalizedSpan.start_time` and `TraceRecord.start_time` are declared
+non-Optional (models.py) because ingest already rejects any record with no
+observed time rather than substituting a default or leaving it unset. A
+`cast(datetime, ... or None)` here used to silently smuggle a `None` past that
+contract when the wire payload was missing `start_time` — which suppressed the
+exact signal that would have caught unguarded downstream dereferences
+(`core/cost.py`, the cache-efficacy and model-downgrade analyzers). These
+tests pin the replacement contract: a genuinely present `start_time` still
+round-trips, and a missing one now raises instead of laundering a `None`
+through as if it were a `datetime`.
+"""
+from __future__ import annotations
+
+import pytest
+
+from tokenjam.core.api_backend import _dict_to_span, _require_start_time
+
+
+def _span_dict(**overrides):
+    d = {
+        "span_id": "sp-1",
+        "trace_id": "tr-1",
+        "name": "llm.completion",
+        "kind": "internal",
+        "status_code": "ok",
+        "start_time": "2026-03-14T12:00:00+00:00",
+    }
+    d.update(overrides)
+    return d
+
+
+def test_dict_to_span_parses_a_present_start_time():
+    span = _dict_to_span(_span_dict())
+    assert span.start_time.isoformat() == "2026-03-14T12:00:00+00:00"
+
+
+def test_dict_to_span_raises_when_start_time_is_missing():
+    """A malformed/incomplete API response must fail loudly, not hand a
+    `None` to a field the type system promises is always a real `datetime`."""
+    with pytest.raises(ValueError, match="start_time"):
+        _dict_to_span(_span_dict(start_time=None))
+
+
+def test_dict_to_span_raises_when_start_time_key_is_absent():
+    d = _span_dict()
+    del d["start_time"]
+    with pytest.raises(ValueError, match="start_time"):
+        _dict_to_span(d)
+
+
+def test_require_start_time_identifies_the_offending_record():
+    with pytest.raises(ValueError, match="sp-1"):
+        _require_start_time({"span_id": "sp-1", "start_time": None})

--- a/tests/unit/test_cmd_status_ingest_freshness.py
+++ b/tests/unit/test_cmd_status_ingest_freshness.py
@@ -1,0 +1,65 @@
+"""`tj status`'s ingest-freshness note (`_ingest_freshness_note`, cmd_status.py).
+
+Purely advisory (unlike `tj doctor`'s "Corpus freshness" check, which shares
+the same threshold math via `core/ingest_freshness.py` but FAILS on it) —
+`tj status` never exits non-zero on a stale corpus, since a quiet corpus is
+also the everyday shape of a user who just hasn't run an agent lately.
+Three-state gating (root anti-pattern 22): silent with no config/DB, silent
+when known-and-fresh, a line only when known-and-stale.
+"""
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+
+from tokenjam.cli.cmd_status import _ingest_freshness_note
+from tokenjam.core.config import IngestConfig, StorageConfig, TjConfig
+from tokenjam.core.db import DuckDBBackend
+from tokenjam.utils.time_parse import utcnow
+from tests.factories import make_session
+
+
+@pytest.fixture()
+def db():
+    backend = DuckDBBackend(StorageConfig(path=":memory:"))
+    yield backend
+    backend.close()
+
+
+def _config() -> TjConfig:
+    config = TjConfig(version="1")
+    config.ingest = IngestConfig(interval_minutes=30)
+    return config
+
+
+def test_silent_with_no_config() -> None:
+    class _NoConn:
+        pass
+
+    assert _ingest_freshness_note(None, _NoConn()) is None
+
+
+def test_silent_when_no_sessions_ever(db: DuckDBBackend) -> None:
+    assert _ingest_freshness_note(_config(), db) is None
+
+
+def test_silent_when_recently_ingested(db: DuckDBBackend) -> None:
+    db.upsert_session(make_session(started_at=utcnow() - timedelta(minutes=5)))
+    assert _ingest_freshness_note(_config(), db) is None
+
+
+def test_fires_when_stale(db: DuckDBBackend) -> None:
+    db.upsert_session(make_session(started_at=utcnow() - timedelta(days=2)))
+    note = _ingest_freshness_note(_config(), db)
+    assert note is not None
+    assert "tj doctor" in note
+
+
+def test_never_raises_on_a_broken_db(monkeypatch) -> None:
+    class _Boom:
+        @property
+        def conn(self):
+            raise RuntimeError("disk on fire")
+
+    assert _ingest_freshness_note(_config(), _Boom()) is None

--- a/tests/unit/test_doctor_corpus_freshness.py
+++ b/tests/unit/test_doctor_corpus_freshness.py
@@ -1,10 +1,18 @@
-"""`tj doctor`'s corpus-freshness check: a stale corpus can never render as
-healthy, and must FAIL (not warn) once nothing is positioned to close the
-gap automatically -- see the daemon-liveness check this pairs with.
+"""`tj doctor`'s corpus-freshness check: a stale-by-age corpus with real
+un-ingested data waiting on disk can never render as healthy, and must FAIL
+(not warn) once nothing is positioned to close the gap automatically -- see
+the daemon-liveness check this pairs with.
+
+Age alone isn't enough to call it a gap, though: a user who simply hasn't run
+Claude Code since the threshold looks identical by wall-clock but has no
+newer on-disk data to ingest. That must read as healthy, not an error -- see
+test_ok_when_stale_but_idle_with_no_newer_transcripts below.
 """
 from __future__ import annotations
 
-from datetime import timedelta
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
 
 import pytest
 
@@ -16,10 +24,18 @@ from tests.factories import make_session
 
 
 @pytest.fixture()
-def db():
-    backend = DuckDBBackend(StorageConfig(path=":memory:"))
+def db(tmp_path: Path):
+    backend = DuckDBBackend(StorageConfig(path=str(tmp_path / "t.duckdb")))
     yield backend
     backend.close()
+
+
+@pytest.fixture()
+def projects_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    root = tmp_path / "projects"
+    root.mkdir()
+    monkeypatch.setenv("TJ_CLAUDE_PROJECTS_ROOT", str(root))
+    return root
 
 
 def _config() -> TjConfig:
@@ -28,37 +44,103 @@ def _config() -> TjConfig:
     return config
 
 
-def test_info_when_no_sessions_ever(db: DuckDBBackend) -> None:
+def _write_session(root: Path, session_id: str, started_at: datetime) -> None:
+    project_dir = root / "-tmp-proj"
+    project_dir.mkdir(parents=True, exist_ok=True)
+    (project_dir / f"{session_id}.jsonl").write_text(json.dumps({
+        "type": "assistant",
+        "uuid": f"{session_id}-u1",
+        "sessionId": session_id,
+        "cwd": "/tmp/proj",
+        "timestamp": started_at.isoformat(),
+        "message": {
+            "id": f"msg_{session_id}",
+            "model": "claude-sonnet-4-5-20250929",
+            "content": [{"type": "text", "text": "ok"}],
+            "usage": {
+                "input_tokens": 100, "output_tokens": 20,
+                "cache_read_input_tokens": 0, "cache_creation_input_tokens": 0,
+            },
+        },
+    }))
+
+
+def test_info_when_no_sessions_ever(db: DuckDBBackend, projects_root: Path) -> None:
     check = _check_corpus_freshness(_config(), db, daemon_alive=True)
     assert check["level"] == "info"
 
 
-def test_ok_when_recently_ingested(db: DuckDBBackend) -> None:
+def test_ok_when_recently_ingested(db: DuckDBBackend, projects_root: Path) -> None:
     db.upsert_session(make_session(started_at=utcnow() - timedelta(minutes=5)))
     check = _check_corpus_freshness(_config(), db, daemon_alive=True)
     assert check["level"] == "ok"
 
 
-def test_warning_when_stale_but_daemon_is_alive(db: DuckDBBackend) -> None:
+def test_ok_when_stale_but_idle_with_no_newer_transcripts(
+    db: DuckDBBackend, projects_root: Path,
+) -> None:
+    """The legitimate-idle-user case: recorded sessions, nothing new on disk,
+    daemon down. Wall-clock age alone would call this an error; it must not."""
     db.upsert_session(make_session(started_at=utcnow() - timedelta(days=2)))
+    check = _check_corpus_freshness(_config(), db, daemon_alive=False)
+    assert check["level"] == "ok"
+    assert "haven't run it" in check["message"]
+
+
+def test_warning_when_stale_with_newer_transcripts_and_daemon_alive(
+    db: DuckDBBackend, projects_root: Path,
+) -> None:
+    db.upsert_session(make_session(started_at=utcnow() - timedelta(days=2)))
+    _write_session(projects_root, "sess-newer", utcnow() - timedelta(hours=1))
+
     check = _check_corpus_freshness(_config(), db, daemon_alive=True)
+
     assert check["level"] == "warning"
 
 
-def test_error_when_stale_and_daemon_is_dead(db: DuckDBBackend) -> None:
-    """This is the real-machine scenario: newest session 2 days stale, and
-    nothing is running to catch it up. Must FAIL, never merely warn."""
+def test_error_when_stale_with_newer_transcripts_and_daemon_dead(
+    db: DuckDBBackend, projects_root: Path,
+) -> None:
+    """This is the real-gap scenario: newest ingested session 2 days stale,
+    newer on-disk data waiting, and nothing running to catch it up. Must
+    FAIL, never merely warn."""
     db.upsert_session(make_session(started_at=utcnow() - timedelta(days=2)))
+    _write_session(projects_root, "sess-newer", utcnow() - timedelta(hours=1))
+
     check = _check_corpus_freshness(_config(), db, daemon_alive=False)
+
     assert check["level"] == "error"
     assert "not running" in check["message"]
 
 
-def test_a_stale_corpus_never_renders_as_ok(db: DuckDBBackend) -> None:
-    """Never assert more than the data supports: a corpus this far past its
-    own configured cadence must never come back level 'ok', regardless of
-    daemon state."""
+def test_a_confirmed_gap_never_renders_as_ok(
+    db: DuckDBBackend, projects_root: Path,
+) -> None:
+    """Never assert more than the data supports: once there's confirmed
+    newer on-disk data waiting, this must never come back level 'ok',
+    regardless of daemon state."""
     db.upsert_session(make_session(started_at=utcnow() - timedelta(days=5)))
+    _write_session(projects_root, "sess-newer", utcnow() - timedelta(hours=1))
     for daemon_alive in (True, False):
         check = _check_corpus_freshness(_config(), db, daemon_alive=daemon_alive)
         assert check["level"] != "ok"
+
+
+def test_info_when_reconciliation_cannot_be_verified(
+    db: DuckDBBackend, projects_root: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A check that can't determine the answer must not render as either
+    healthy or failing."""
+    db.upsert_session(make_session(started_at=utcnow() - timedelta(days=2)))
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("disk on fire")
+
+    monkeypatch.setattr(
+        "tokenjam.core.transcript_sync.reconcile_claude_code", _boom
+    )
+
+    check = _check_corpus_freshness(_config(), db, daemon_alive=True)
+
+    assert check["level"] == "info"
+    assert "disk on fire" in check["message"]

--- a/tests/unit/test_doctor_corpus_freshness.py
+++ b/tests/unit/test_doctor_corpus_freshness.py
@@ -1,0 +1,64 @@
+"""`tj doctor`'s corpus-freshness check: a stale corpus can never render as
+healthy, and must FAIL (not warn) once nothing is positioned to close the
+gap automatically -- see the daemon-liveness check this pairs with.
+"""
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+
+from tokenjam.cli.cmd_doctor import _check_corpus_freshness
+from tokenjam.core.config import IngestConfig, StorageConfig, TjConfig
+from tokenjam.core.db import DuckDBBackend
+from tokenjam.utils.time_parse import utcnow
+from tests.factories import make_session
+
+
+@pytest.fixture()
+def db():
+    backend = DuckDBBackend(StorageConfig(path=":memory:"))
+    yield backend
+    backend.close()
+
+
+def _config() -> TjConfig:
+    config = TjConfig(version="1")
+    config.ingest = IngestConfig(interval_minutes=30)
+    return config
+
+
+def test_info_when_no_sessions_ever(db: DuckDBBackend) -> None:
+    check = _check_corpus_freshness(_config(), db, daemon_alive=True)
+    assert check["level"] == "info"
+
+
+def test_ok_when_recently_ingested(db: DuckDBBackend) -> None:
+    db.upsert_session(make_session(started_at=utcnow() - timedelta(minutes=5)))
+    check = _check_corpus_freshness(_config(), db, daemon_alive=True)
+    assert check["level"] == "ok"
+
+
+def test_warning_when_stale_but_daemon_is_alive(db: DuckDBBackend) -> None:
+    db.upsert_session(make_session(started_at=utcnow() - timedelta(days=2)))
+    check = _check_corpus_freshness(_config(), db, daemon_alive=True)
+    assert check["level"] == "warning"
+
+
+def test_error_when_stale_and_daemon_is_dead(db: DuckDBBackend) -> None:
+    """This is the real-machine scenario: newest session 2 days stale, and
+    nothing is running to catch it up. Must FAIL, never merely warn."""
+    db.upsert_session(make_session(started_at=utcnow() - timedelta(days=2)))
+    check = _check_corpus_freshness(_config(), db, daemon_alive=False)
+    assert check["level"] == "error"
+    assert "not running" in check["message"]
+
+
+def test_a_stale_corpus_never_renders_as_ok(db: DuckDBBackend) -> None:
+    """Never assert more than the data supports: a corpus this far past its
+    own configured cadence must never come back level 'ok', regardless of
+    daemon state."""
+    db.upsert_session(make_session(started_at=utcnow() - timedelta(days=5)))
+    for daemon_alive in (True, False):
+        check = _check_corpus_freshness(_config(), db, daemon_alive=daemon_alive)
+        assert check["level"] != "ok"

--- a/tests/unit/test_doctor_daemon_liveness.py
+++ b/tests/unit/test_doctor_daemon_liveness.py
@@ -1,0 +1,46 @@
+"""`tj doctor` must FAIL when a background daemon is installed but not
+actually running -- observed on a real machine: the launchd plist was
+present (`RunAtLoad`/`KeepAlive` both true, no `Disabled` key) yet
+`launchctl list` showed nothing loaded, with no crash and no error trace.
+Nothing anywhere said ingestion had silently stopped.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tokenjam.cli.cmd_doctor import _check_daemon_liveness
+
+
+def test_ok_when_daemon_is_alive() -> None:
+    check = _check_daemon_liveness(daemon_alive=True)
+    assert check["level"] == "ok"
+
+
+def test_info_when_nothing_installed_and_nothing_running(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No install and no running process is a legitimate pre-onboard / manual
+    `tj serve` state -- not an error."""
+    monkeypatch.setattr(
+        "tokenjam.cli.cmd_doctor._daemon_install_path", lambda: None,
+    )
+    check = _check_daemon_liveness(daemon_alive=False)
+    assert check["level"] == "info"
+
+
+def test_errors_when_installed_but_not_running(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The exact production failure mode: a registration exists on disk but
+    the process isn't actually up. Must FAIL, not warn."""
+    plist = tmp_path / "com.tokenjam.serve.plist"
+    plist.write_text("<plist/>")
+    monkeypatch.setattr(
+        "tokenjam.cli.cmd_doctor._daemon_install_path", lambda: plist,
+    )
+    check = _check_daemon_liveness(daemon_alive=False)
+    assert check["level"] == "error"
+    assert "not running" in check["message"]
+    assert str(plist) in check["message"]

--- a/tests/unit/test_doctor_transcript_gap.py
+++ b/tests/unit/test_doctor_transcript_gap.py
@@ -102,6 +102,31 @@ def test_is_informational_when_no_transcripts_exist(
     assert check["level"] == "info"
 
 
+def test_escalates_to_error_when_the_daemon_is_not_running(
+    db: DuckDBBackend, projects_root: Path,
+) -> None:
+    """A gap that nothing is positioned to close automatically must FAIL, not
+    warn — daemon down means `auto_catch_up` structurally cannot run."""
+    _write_session(projects_root, "sess-dropped")
+
+    check = _check_transcript_ingest_gap(TjConfig(version="1"), db, daemon_alive=False)
+
+    assert check["level"] == "error"
+    assert "background daemon is not running" in check["message"]
+
+
+def test_stays_a_warning_when_the_daemon_is_running_and_auto_catch_up_is_on(
+    db: DuckDBBackend, projects_root: Path,
+) -> None:
+    """Explicit True (matching the default) still self-heals — a live daemon
+    with auto-catch-up on should close the gap on its own next pass."""
+    _write_session(projects_root, "sess-dropped")
+
+    check = _check_transcript_ingest_gap(TjConfig(version="1"), db, daemon_alive=True)
+
+    assert check["level"] == "warning"
+
+
 def test_never_raises_when_the_comparison_fails(
     db: DuckDBBackend, projects_root: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_ingest_freshness.py
+++ b/tests/unit/test_ingest_freshness.py
@@ -1,0 +1,55 @@
+"""`core/ingest_freshness.py` is the single source of truth `tj doctor` and
+`tj status` both read the corpus-staleness threshold from -- pinned here so
+neither surface can silently drift from the other on what "stale" means.
+"""
+from __future__ import annotations
+
+from datetime import timedelta
+
+from tokenjam.core.config import StorageConfig
+from tokenjam.core.db import DuckDBBackend
+from tokenjam.core.ingest_freshness import corpus_freshness, staleness_threshold_hours
+from tokenjam.utils.time_parse import utcnow
+from tests.factories import make_session
+
+
+def test_threshold_scales_with_the_configured_interval() -> None:
+    assert staleness_threshold_hours(30) > staleness_threshold_hours(15)
+
+
+def test_threshold_never_drops_below_the_floor_for_a_tiny_interval() -> None:
+    from tokenjam.core.ingest_freshness import STALENESS_FLOOR_HOURS
+
+    assert staleness_threshold_hours(1) == STALENESS_FLOOR_HOURS
+
+
+def test_no_sessions_is_not_stale() -> None:
+    db = DuckDBBackend(StorageConfig(path=":memory:"))
+    try:
+        result = corpus_freshness(db.conn, 30, now=utcnow())
+    finally:
+        db.close()
+    assert result.newest_session_at is None
+    assert result.is_stale is False
+
+
+def test_a_recent_session_is_not_stale() -> None:
+    db = DuckDBBackend(StorageConfig(path=":memory:"))
+    try:
+        db.upsert_session(make_session(started_at=utcnow() - timedelta(minutes=5)))
+        result = corpus_freshness(db.conn, 30, now=utcnow())
+    finally:
+        db.close()
+    assert result.is_stale is False
+
+
+def test_a_session_far_past_the_cadence_is_stale() -> None:
+    db = DuckDBBackend(StorageConfig(path=":memory:"))
+    try:
+        now = utcnow()
+        db.upsert_session(make_session(started_at=now - timedelta(days=2)))
+        result = corpus_freshness(db.conn, 30, now=now)
+    finally:
+        db.close()
+    assert result.is_stale is True
+    assert result.age_hours is not None and result.age_hours > 47

--- a/tests/unit/test_onboard_daemon.py
+++ b/tests/unit/test_onboard_daemon.py
@@ -6,6 +6,23 @@ from unittest.mock import patch, MagicMock
 from tokenjam.cli.cmd_onboard import _daemon_already_running
 
 
+def _print_stdout(program_args: list[str]) -> str:
+    """A `launchctl print` text body reporting an active unit whose
+    `arguments` array is exactly `program_args` — what `_install_launchd`'s
+    post-install content check parses out and compares."""
+    args_block = "\n".join(f"\t\t{a}" for a in program_args)
+    return (
+        "gui/501/com.tokenjam.serve = {\n"
+        "\tactive count = 1\n"
+        "\tstate = running\n\n"
+        f"\tprogram = {program_args[0]}\n"
+        "\targuments = {\n"
+        f"{args_block}\n"
+        "\t}\n"
+        "}\n"
+    )
+
+
 class TestDaemonAlreadyRunning:
     def test_darwin_plist_exists_and_loaded(self, tmp_path, monkeypatch):
         """Returns True on macOS when plist exists and launchctl list succeeds."""
@@ -197,7 +214,14 @@ class TestLaunchdInstallSurvivesRegistration:
         monkeypatch.setattr("tokenjam.cli.cmd_onboard.shutil.which", lambda _: "/usr/bin/tj")
         monkeypatch.setattr("tokenjam.cli.cmd_onboard.os.getuid", lambda: 501, raising=False)
 
-        run_mock = MagicMock(return_value=MagicMock(returncode=0, stdout="", stderr=""))
+        program_args = ["/usr/bin/tj", "--config", "/tmp/cfg.toml", "serve"]
+
+        def _run(cmd, **kwargs):
+            if cmd[1] == "print":
+                return MagicMock(returncode=0, stdout=_print_stdout(program_args), stderr="")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        run_mock = MagicMock(side_effect=_run)
         with patch("tokenjam.cli.cmd_onboard.subprocess.run", run_mock):
             result = _install_launchd("/tmp/cfg.toml")
 
@@ -242,24 +266,62 @@ class TestLaunchdInstallSurvivesRegistration:
 
         assert result is None
 
-    def test_install_tolerates_already_bootstrapped_as_idempotent(self, tmp_path, monkeypatch):
+    def test_install_tolerates_already_bootstrapped_when_content_matches(
+        self, tmp_path, monkeypatch,
+    ):
         """A re-onboard racing the `bootout` above (or one that no-op'd
         against a job still shutting down) must not be reported as a failed
-        install, so long as the independent verification confirms it's
-        actually registered."""
+        install, so long as the independent verification confirms the
+        ACTIVE unit's program arguments match what was just written — not
+        merely that some unit with that label exists."""
         from tokenjam.cli.cmd_onboard import _install_launchd
         monkeypatch.setattr("tokenjam.cli.cmd_onboard.Path.home", lambda: tmp_path)
         monkeypatch.setattr("tokenjam.cli.cmd_onboard.shutil.which", lambda _: "/usr/bin/tj")
 
+        program_args = ["/usr/bin/tj", "--config", "/tmp/cfg.toml", "serve"]
+
         def _run(cmd, **kwargs):
             if cmd[1] == "bootstrap":
                 return MagicMock(returncode=1, stdout="", stderr="Service already bootstrapped")
+            if cmd[1] == "print":
+                return MagicMock(returncode=0, stdout=_print_stdout(program_args), stderr="")
             return MagicMock(returncode=0, stdout="", stderr="")
 
         with patch("tokenjam.cli.cmd_onboard.subprocess.run", side_effect=_run):
             result = _install_launchd("/tmp/cfg.toml")
 
         assert result is not None
+
+    def test_install_fails_when_already_bootstrapped_verifies_the_old_unit(
+        self, tmp_path, monkeypatch,
+    ):
+        """The exact defect this fix closes: `bootout` didn't actually clear
+        the previous registration, `bootstrap` reports "already bootstrapped"
+        (meaning the OLD unit is still loaded), and `launchctl print` happily
+        confirms that old label — with OLD program arguments (a stale
+        executable/config path), not the new plist just written. A bare
+        "label exists" check would pass this; the content check must fail
+        it loudly instead of reporting a false success."""
+        from tokenjam.cli.cmd_onboard import _install_launchd
+        monkeypatch.setattr("tokenjam.cli.cmd_onboard.Path.home", lambda: tmp_path)
+        monkeypatch.setattr("tokenjam.cli.cmd_onboard.shutil.which", lambda _: "/usr/bin/tj")
+
+        old_program_args = ["/usr/bin/tj", "--config", "/tmp/OLD-cfg.toml", "serve"]
+
+        def _run(cmd, **kwargs):
+            if cmd[1] == "bootstrap":
+                return MagicMock(returncode=1, stdout="", stderr="Service already bootstrapped")
+            if cmd[1] == "print":
+                # Always reports the OLD unit, even after the retry's
+                # bootout/bootstrap — simulating a registration that never
+                # actually gets replaced.
+                return MagicMock(returncode=0, stdout=_print_stdout(old_program_args), stderr="")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("tokenjam.cli.cmd_onboard.subprocess.run", side_effect=_run):
+            result = _install_launchd("/tmp/cfg.toml")
+
+        assert result is None
 
 
 class TestTjBinaryResolution:
@@ -433,10 +495,17 @@ class TestDaemonSurvivesUvCachePrune:
             "tokenjam.cli.cmd_onboard.shutil.which",
             lambda b: "/Users/x/.local/bin/uvx" if b == "uvx" else None,
         )
-        with patch(
-            "tokenjam.cli.cmd_onboard.subprocess.run",
-            MagicMock(return_value=MagicMock(returncode=0)),
-        ):
+        program_args = [
+            "/Users/x/.local/bin/uvx", "--from", "tokenjam", "tj",
+            "--config", "/tmp/cfg.toml", "serve",
+        ]
+
+        def _run(cmd, **kwargs):
+            if cmd[1] == "print":
+                return MagicMock(returncode=0, stdout=_print_stdout(program_args), stderr="")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("tokenjam.cli.cmd_onboard.subprocess.run", side_effect=_run):
             result = _install_launchd("/tmp/cfg.toml")
 
         assert result is not None

--- a/tests/unit/test_onboard_daemon.py
+++ b/tests/unit/test_onboard_daemon.py
@@ -172,27 +172,94 @@ class TestRepeatOnboardDoesNotChurnDaemon:
         assert restart_msg == "restarted"
 
 
-class TestLaunchdInstallUsesWFlag:
-    """`_install_launchd` must pass -w to both unload and load so it clears
-    the Disabled=true flag that `tj stop` writes (C1)."""
+class TestLaunchdInstallSurvivesRegistration:
+    """`_install_launchd` must use the modern `bootstrap`/`enable`/`bootout`
+    subcommands, never the legacy `load`/`unload` — the `launchctl` man page
+    marks load/unload legacy and warns they "will only return a non-zero exit
+    code due to improper usage. Otherwise, zero is always returned", so a
+    silently-failed registration is invisible to a caller that only checks
+    the exit code (the actual production failure mode this fix addresses:
+    the plist was present, `RunAtLoad`/`KeepAlive` both true, no `Disabled`
+    key, yet the unit was simply never re-loaded into launchd).
 
-    def test_load_uses_w_flag(self, tmp_path, monkeypatch):
+    Formerly `TestLaunchdInstallUsesWFlag` (C1), which pinned `load -w` /
+    `unload -w` clearing the Disabled flag `tj stop` writes. `enable` is the
+    modern equivalent of that disable-clearing half; this class re-asserts
+    the same guarantee against the new mechanism (Critical Rule 23 in the
+    project's `.claude/rules` — invert a superseded assertion rather than
+    dropping the coverage) and adds the independent post-install
+    verification the old mechanism never did.
+    """
+
+    def test_install_bootouts_enables_bootstraps_and_verifies(self, tmp_path, monkeypatch):
+        from tokenjam.cli.cmd_onboard import _install_launchd
+        monkeypatch.setattr("tokenjam.cli.cmd_onboard.Path.home", lambda: tmp_path)
+        monkeypatch.setattr("tokenjam.cli.cmd_onboard.shutil.which", lambda _: "/usr/bin/tj")
+        monkeypatch.setattr("tokenjam.cli.cmd_onboard.os.getuid", lambda: 501, raising=False)
+
+        run_mock = MagicMock(return_value=MagicMock(returncode=0, stdout="", stderr=""))
+        with patch("tokenjam.cli.cmd_onboard.subprocess.run", run_mock):
+            result = _install_launchd("/tmp/cfg.toml")
+
+        assert result is not None
+        calls = [c.args[0] for c in run_mock.call_args_list]
+        subcommands = [c[1] for c in calls]
+        assert "bootout" in subcommands
+        assert "enable" in subcommands
+        assert "bootstrap" in subcommands
+        assert "print" in subcommands
+        # Never the deprecated legacy calls this replaces.
+        assert "load" not in subcommands
+        assert "unload" not in subcommands
+
+        target = "gui/501/com.tokenjam.serve"
+        enable_call = next(c for c in calls if c[1] == "enable")
+        assert enable_call[-1] == target
+        bootout_call = next(c for c in calls if c[1] == "bootout")
+        assert bootout_call[-1] == target
+        print_call = next(c for c in calls if c[1] == "print")
+        assert print_call[-1] == target
+        bootstrap_call = next(c for c in calls if c[1] == "bootstrap")
+        assert bootstrap_call[2] == "gui/501"
+
+    def test_install_fails_when_verification_shows_not_registered(self, tmp_path, monkeypatch):
+        """`bootstrap` can report success while the service never actually
+        registers — the same "exit code lies" failure mode this fix exists
+        for. The install must be reported as FAILED when the independent
+        `print` verification can't find the label, not only when bootstrap
+        itself errors."""
         from tokenjam.cli.cmd_onboard import _install_launchd
         monkeypatch.setattr("tokenjam.cli.cmd_onboard.Path.home", lambda: tmp_path)
         monkeypatch.setattr("tokenjam.cli.cmd_onboard.shutil.which", lambda _: "/usr/bin/tj")
 
-        run_mock = MagicMock(return_value=MagicMock(returncode=0))
-        with patch("tokenjam.cli.cmd_onboard.subprocess.run", run_mock):
-            _install_launchd("/tmp/cfg.toml")
+        def _run(cmd, **kwargs):
+            if cmd[1] == "print":
+                return MagicMock(returncode=3, stdout="", stderr="Could not find service")
+            return MagicMock(returncode=0, stdout="", stderr="")
 
-        # Both unload and load must include -w
-        calls = [c.args[0] for c in run_mock.call_args_list]
-        assert any("unload" in c and "-w" in c for c in calls), (
-            f"unload should use -w; calls were {calls}"
-        )
-        assert any("load" in c and "-w" in c for c in calls), (
-            f"load should use -w; calls were {calls}"
-        )
+        with patch("tokenjam.cli.cmd_onboard.subprocess.run", side_effect=_run):
+            result = _install_launchd("/tmp/cfg.toml")
+
+        assert result is None
+
+    def test_install_tolerates_already_bootstrapped_as_idempotent(self, tmp_path, monkeypatch):
+        """A re-onboard racing the `bootout` above (or one that no-op'd
+        against a job still shutting down) must not be reported as a failed
+        install, so long as the independent verification confirms it's
+        actually registered."""
+        from tokenjam.cli.cmd_onboard import _install_launchd
+        monkeypatch.setattr("tokenjam.cli.cmd_onboard.Path.home", lambda: tmp_path)
+        monkeypatch.setattr("tokenjam.cli.cmd_onboard.shutil.which", lambda _: "/usr/bin/tj")
+
+        def _run(cmd, **kwargs):
+            if cmd[1] == "bootstrap":
+                return MagicMock(returncode=1, stdout="", stderr="Service already bootstrapped")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("tokenjam.cli.cmd_onboard.subprocess.run", side_effect=_run):
+            result = _install_launchd("/tmp/cfg.toml")
+
+        assert result is not None
 
 
 class TestTjBinaryResolution:

--- a/tests/unit/test_onboard_daemon.py
+++ b/tests/unit/test_onboard_daemon.py
@@ -211,6 +211,12 @@ class TestLaunchdInstallSurvivesRegistration:
     def test_install_bootouts_enables_bootstraps_and_verifies(self, tmp_path, monkeypatch):
         from tokenjam.cli.cmd_onboard import _install_launchd
         monkeypatch.setattr("tokenjam.cli.cmd_onboard.Path.home", lambda: tmp_path)
+        # No real `tj` sibling next to this fake interpreter, so
+        # `_resolve_tj_binary` falls through to the mocked `which` below —
+        # on a real venv (CI installs the package editable) a genuine `tj`
+        # console-script sibling can otherwise outrank the mock and change
+        # the actual program args this test hardcodes.
+        monkeypatch.setattr("tokenjam.cli.cmd_onboard.sys.executable", str(tmp_path / "python3"))
         monkeypatch.setattr("tokenjam.cli.cmd_onboard.shutil.which", lambda _: "/usr/bin/tj")
         monkeypatch.setattr("tokenjam.cli.cmd_onboard.os.getuid", lambda: 501, raising=False)
 
@@ -254,6 +260,7 @@ class TestLaunchdInstallSurvivesRegistration:
         itself errors."""
         from tokenjam.cli.cmd_onboard import _install_launchd
         monkeypatch.setattr("tokenjam.cli.cmd_onboard.Path.home", lambda: tmp_path)
+        monkeypatch.setattr("tokenjam.cli.cmd_onboard.sys.executable", str(tmp_path / "python3"))
         monkeypatch.setattr("tokenjam.cli.cmd_onboard.shutil.which", lambda _: "/usr/bin/tj")
 
         def _run(cmd, **kwargs):
@@ -276,6 +283,7 @@ class TestLaunchdInstallSurvivesRegistration:
         merely that some unit with that label exists."""
         from tokenjam.cli.cmd_onboard import _install_launchd
         monkeypatch.setattr("tokenjam.cli.cmd_onboard.Path.home", lambda: tmp_path)
+        monkeypatch.setattr("tokenjam.cli.cmd_onboard.sys.executable", str(tmp_path / "python3"))
         monkeypatch.setattr("tokenjam.cli.cmd_onboard.shutil.which", lambda _: "/usr/bin/tj")
 
         program_args = ["/usr/bin/tj", "--config", "/tmp/cfg.toml", "serve"]
@@ -304,6 +312,7 @@ class TestLaunchdInstallSurvivesRegistration:
         it loudly instead of reporting a false success."""
         from tokenjam.cli.cmd_onboard import _install_launchd
         monkeypatch.setattr("tokenjam.cli.cmd_onboard.Path.home", lambda: tmp_path)
+        monkeypatch.setattr("tokenjam.cli.cmd_onboard.sys.executable", str(tmp_path / "python3"))
         monkeypatch.setattr("tokenjam.cli.cmd_onboard.shutil.which", lambda _: "/usr/bin/tj")
 
         old_program_args = ["/usr/bin/tj", "--config", "/tmp/OLD-cfg.toml", "serve"]

--- a/tests/unit/test_optimize.py
+++ b/tests/unit/test_optimize.py
@@ -1,7 +1,7 @@
 """Unit tests for the tj optimize analyzers."""
 from __future__ import annotations
 
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -78,6 +78,29 @@ def test_summarize_window_counts_and_costs(db):
     assert s.sessions == 2
     assert s.total_tokens == 1000 + 200 + 50_000 + 2_000
     assert abs(s.total_cost_usd - (0.030 + 1.500)) < 1e-6
+
+
+@pytest.mark.parametrize("db_timezone", ["UTC", "Asia/Kolkata", "America/Los_Angeles"])
+def test_summarize_window_active_days_buckets_on_the_utc_date(db, db_timezone):
+    """``active_days`` feeds every per-day extrapolation in the optimize
+    report, so it must count distinct UTC dates, not local ones.
+
+    A bare ``CAST(start_time AS DATE)`` resolves a TIMESTAMPTZ through the
+    connection's local timezone before truncating. Two spans that straddle
+    UTC midnight (one at 23:30 UTC, one 1h later at 00:30 UTC the next day —
+    genuinely 2 distinct UTC dates) both land on the SAME local date once
+    shifted by a several-hour offset in either direction, so a buggy bucket
+    collapses them to one day and understates ``active_days``.
+    """
+    db.conn.execute(f"SET TimeZone='{db_timezone}'")
+    day1_2330 = datetime(2026, 3, 14, 23, 30, tzinfo=timezone.utc)
+    day2_0030 = datetime(2026, 3, 15, 0, 30, tzinfo=timezone.utc)
+    _insert_small_opus_session(db, start_time=day1_2330, session_id="a")
+    _insert_small_opus_session(db, start_time=day2_0030, session_id="b")
+    since = day1_2330 - timedelta(hours=2)
+    until = day2_0030 + timedelta(hours=2)
+    s = summarize_window(db.conn, since, until)
+    assert s.active_days == 2
 
 
 def test_summarize_window_total_includes_cache_read_tokens(db):

--- a/tokenjam/cli/cmd_doctor.py
+++ b/tokenjam/cli/cmd_doctor.py
@@ -1177,10 +1177,16 @@ def _check_corpus_freshness(config: object, db: object, daemon_alive: bool) -> d
     interval_minutes` cadence (`core/ingest_freshness.py`, shared with `tj
     status`'s advisory line so the two can't disagree on what "stale" means).
 
-    Severity depends on whether anything is currently positioned to close a
-    real gap on its own: with the daemon down, a stale corpus can only get
-    staler, so this FAILS; with the daemon up, the same gap is a WARNING —
-    the next scheduled catch-up may well close it before anyone needs to act.
+    Wall-clock age alone can't tell "ingestion is lagging" apart from "the
+    user simply hasn't run Claude Code since" — both look identical from the
+    `sessions` table. So a stale-by-age result is only PROVISIONAL: it's
+    confirmed as a real gap by checking for on-disk transcript data newer
+    than what's ingested (the same reconciliation `_check_transcript_ingest_gap`
+    below uses), and downgraded to healthy when there is none. Severity for a
+    confirmed gap depends on whether anything is currently positioned to
+    close it on its own: with the daemon down, a real gap can only get
+    staler, so this FAILS; with the daemon up, it's a WARNING — the next
+    scheduled catch-up may well close it before anyone needs to act.
     """
     name = "Corpus freshness"
     conn = getattr(db, "conn", None)
@@ -1205,6 +1211,38 @@ def _check_corpus_freshness(config: object, db: object, daemon_alive: bool) -> d
         return {"name": name, "level": "ok",
                 "message": f"Newest session started {freshness.age_hours:.1f}h ago."}
 
+    # Stale by age — confirm there's actually un-ingested data waiting,
+    # rather than the user just being idle, before calling it a gap.
+    try:
+        from tokenjam.core.transcript_sync import reconcile_claude_code
+
+        report = reconcile_claude_code(db, since=freshness.newest_session_at)
+    except Exception as e:  # never let a health check crash `tj doctor`
+        return {"name": name, "level": "info",
+                "message": f"Newest session started {freshness.age_hours:.1f}h ago; "
+                           f"couldn't check on-disk transcripts to confirm this is "
+                           f"a real ingestion gap: {e}"}
+
+    if not report.verified:
+        # Same "can't confidently render either way" case _check_transcript_
+        # ingest_gap guards against (#642) — the anti-join never ran, so the
+        # missing-count below would be meaningless.
+        return {"name": name, "level": "info",
+                "message": f"Newest session started {freshness.age_hours:.1f}h ago; "
+                           "couldn't verify against on-disk transcripts to confirm "
+                           "this is a real ingestion gap."}
+
+    if report.missing_count == 0:
+        return {
+            "name": name,
+            "level": "ok",
+            "message": (
+                f"Newest session started {freshness.age_hours:.1f}h ago, but "
+                "there's no newer on-disk Claude Code data waiting to be "
+                "ingested — you just haven't run it since."
+            ),
+        }
+
     level = "warning" if daemon_alive else "error"
     remedy = (
         " `tj serve` is running, so this should close on its own by the next "
@@ -1219,7 +1257,8 @@ def _check_corpus_freshness(config: object, db: object, daemon_alive: bool) -> d
         "level": level,
         "message": (
             f"Newest session started {freshness.age_hours:.1f}h ago (expected "
-            f"roughly every {interval_minutes}m).{remedy}"
+            f"roughly every {interval_minutes}m), and {report.missing_count} "
+            f"newer on-disk session(s) aren't ingested yet.{remedy}"
         ),
     }
 

--- a/tokenjam/cli/cmd_doctor.py
+++ b/tokenjam/cli/cmd_doctor.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import platform
+from pathlib import Path
 
 import click
 import duckdb
@@ -11,6 +13,7 @@ from tokenjam.cli.tj_status import TjCommand
 from tokenjam.core.config import load_config, resolve_config_path
 from tokenjam.core.data_span import MIN_PLAUSIBLE_YEAR
 from tokenjam.core.db import SPANS_INDEXES
+from tokenjam.core.server_state import find_own_serve_pid
 from tokenjam.utils.formatting import console, display_path
 
 
@@ -78,6 +81,19 @@ def cmd_doctor(ctx: click.Context, output_json_flag: bool, repair: bool) -> None
     # 10. Live-span staleness — flags a stalled OTLP connection (issue #179)
     checks.append(_check_span_staleness(ctx.obj["db"]))
 
+    # 10b. Background daemon liveness — is `tj serve` actually running, not
+    #      just installed. Computed once and reused by the corpus-freshness
+    #      and transcript-gap checks below so all three agree on whether
+    #      anything is currently positioned to self-heal a gap.
+    daemon_alive = find_own_serve_pid() is not None
+    checks.append(_check_daemon_liveness(daemon_alive))
+
+    # 10c. Corpus freshness — newest ingested session vs the configured
+    #      ingest cadence. FAILS (not warns) when nothing is live to close
+    #      the gap on its own, since that's silent, unbounded data loss
+    #      rather than a transient lag.
+    checks.append(_check_corpus_freshness(config, ctx.obj["db"], daemon_alive))
+
     # 11. Proxy base-URL wiring consistency (issue #219)
     checks.append(_check_proxy_wiring(config))
 
@@ -95,7 +111,7 @@ def cmd_doctor(ctx: click.Context, output_json_flag: bool, repair: bool) -> None
 
     # 16. Transcript ingest completeness — on-disk sessions never ingested,
     #     still recoverable only until Claude Code prunes the transcript.
-    checks.append(_check_transcript_ingest_gap(config, ctx.obj["db"]))
+    checks.append(_check_transcript_ingest_gap(config, ctx.obj["db"], daemon_alive))
 
     # 17. Cost integrity — sessions.total_cost_usd vs SUM(spans.cost_usd)
     checks.append(_check_cost_integrity(ctx.obj["db"]))
@@ -1089,7 +1105,126 @@ def _check_span_staleness(db: object) -> dict:
             "message": f"Most recent span is {age_hours:.1f}h old."}
 
 
-def _check_transcript_ingest_gap(config: object, db: object) -> dict:
+# macOS/Linux paths a background daemon installs itself under (see
+# `cmd_onboard._install_launchd` / `_install_systemd`). Presence means the
+# user opted into continuous background capture — used only to phrase the
+# liveness message; the liveness question itself is answered by
+# `find_own_serve_pid()`, which works the same whether `tj serve` is running
+# as a managed daemon or was started by hand.
+def _daemon_install_path() -> Path | None:
+    system = platform.system()
+    if system == "Darwin":
+        return Path.home() / "Library/LaunchAgents/com.tokenjam.serve.plist"
+    if system == "Linux":
+        return Path.home() / ".config/systemd/user/tokenjam.service"
+    return None
+
+
+def _daemon_liveness_hint() -> str:
+    system = platform.system()
+    if system == "Darwin":
+        return ("Check with `launchctl print gui/$(id -u)/com.tokenjam.serve`, then "
+                "re-register with `tj onboard --claude-code --reconfigure` or run "
+                "`tj serve` manually.")
+    if system == "Linux":
+        return ("Check with `systemctl --user status tokenjam`, then re-register with "
+                "`tj onboard --claude-code --reconfigure` or run `tj serve` manually.")
+    return "Run `tj serve` manually."
+
+
+def _check_daemon_liveness(daemon_alive: bool) -> dict:
+    """Is `tj serve` actually running right now — not just installed.
+
+    `find_own_serve_pid()` reads the state file `tj serve`'s own lifespan
+    writes after binding its port, so this is true liveness (a real running
+    process), independent of HOW it was started — managed daemon or a
+    manually foregrounded `tj serve` both count. A background install that
+    exists on disk but isn't currently loaded/running is the exact failure
+    mode that motivated this check: on a real machine the launchd plist was
+    present with `RunAtLoad`/`KeepAlive` both true and no `Disabled` key, yet
+    `launchctl list` showed nothing loaded and there was no error trace —
+    ingestion had simply stopped, silently, with no signal anywhere else.
+    """
+    name = "Background daemon liveness"
+    if daemon_alive:
+        return {"name": name, "level": "ok", "message": "`tj serve` is running."}
+
+    install_path = _daemon_install_path()
+    if install_path is None or not install_path.exists():
+        return {
+            "name": name,
+            "level": "info",
+            "message": ("No background daemon installed and `tj serve` is not "
+                        "running — run `tj serve` manually, or `tj onboard` to "
+                        "install one."),
+        }
+    return {
+        "name": name,
+        "level": "error",
+        "message": (
+            f"A background daemon is installed ({install_path}) but `tj serve` "
+            f"is not running. Ingestion, alerts, and the web UI are all silently "
+            f"paused — Claude Code prunes its own on-disk transcripts, so every "
+            f"hour this stays down is history moving closer to being unrecoverable. "
+            f"{_daemon_liveness_hint()}"
+        ),
+    }
+
+
+def _check_corpus_freshness(config: object, db: object, daemon_alive: bool) -> dict:
+    """Compare the newest ingested `sessions.started_at` to wall-clock,
+    against a threshold derived from the daemon's own `[ingest]
+    interval_minutes` cadence (`core/ingest_freshness.py`, shared with `tj
+    status`'s advisory line so the two can't disagree on what "stale" means).
+
+    Severity depends on whether anything is currently positioned to close a
+    real gap on its own: with the daemon down, a stale corpus can only get
+    staler, so this FAILS; with the daemon up, the same gap is a WARNING —
+    the next scheduled catch-up may well close it before anyone needs to act.
+    """
+    name = "Corpus freshness"
+    conn = getattr(db, "conn", None)
+    if conn is None:
+        return {"name": name, "level": "info",
+                "message": "Skipped — CLI is running through the HTTP API "
+                           "fallback (stop `tj serve` to access the DB directly)."}
+    interval_minutes = getattr(getattr(config, "ingest", None), "interval_minutes", 30)
+    try:
+        from tokenjam.core.ingest_freshness import corpus_freshness
+        from tokenjam.utils.time_parse import utcnow
+
+        freshness = corpus_freshness(conn, interval_minutes, now=utcnow())
+    except duckdb.Error as e:
+        return {"name": name, "level": "info",
+                "message": f"Skipped — could not query session timestamps: {e}"}
+
+    if freshness.newest_session_at is None:
+        return {"name": name, "level": "info",
+                "message": "No sessions recorded yet — nothing to check."}
+    if not freshness.is_stale:
+        return {"name": name, "level": "ok",
+                "message": f"Newest session started {freshness.age_hours:.1f}h ago."}
+
+    level = "warning" if daemon_alive else "error"
+    remedy = (
+        " `tj serve` is running, so this should close on its own by the next "
+        "scheduled catch-up; run `tj backfill claude-code` to close it now."
+        if daemon_alive else
+        " The background daemon is not running (see the liveness check above) "
+        "— nothing is ingesting until it's back. Run `tj backfill claude-code` "
+        "to close the gap once it is."
+    )
+    return {
+        "name": name,
+        "level": level,
+        "message": (
+            f"Newest session started {freshness.age_hours:.1f}h ago (expected "
+            f"roughly every {interval_minutes}m).{remedy}"
+        ),
+    }
+
+
+def _check_transcript_ingest_gap(config: object, db: object, daemon_alive: bool = True) -> dict:
     """Surface on-disk Claude Code sessions that were never ingested.
 
     The live OTLP path drops any session whose shell lacked the telemetry env
@@ -1103,6 +1238,12 @@ def _check_transcript_ingest_gap(config: object, db: object) -> dict:
     Scoped to a recent window so the check stays fast and only reports sessions
     that are still recoverable — anything older than the rotation horizon is
     gone regardless of what we say about it.
+
+    Severity mirrors `_check_corpus_freshness`: a gap is only a WARNING while
+    the daemon is up and `auto_catch_up` is on — both conditions under which
+    the gap can plausibly close on its own on the next scheduled pass. Either
+    one being false means nothing is going to fix this without a human
+    running `tj backfill claude-code`, which is a FAIL, not a nag.
     """
     from datetime import timedelta
 
@@ -1136,13 +1277,19 @@ def _check_transcript_ingest_gap(config: object, db: object) -> dict:
     horizon = (f" Oldest is ~{days_left:.0f} day(s) from being pruned."
                if days_left is not None else "")
     auto = getattr(getattr(config, "ingest", None), "auto_catch_up", False)
-    remedy = (" `tj serve` will catch up automatically; run `tj backfill claude-code` "
-              "to close it now." if auto else
-              " Automatic catch-up is off ([ingest] auto_catch_up) — run "
-              "`tj backfill claude-code`.")
+    self_heals = daemon_alive and auto
+    if self_heals:
+        remedy = (" `tj serve` will catch up automatically; run `tj backfill claude-code` "
+                  "to close it now.")
+    elif not daemon_alive:
+        remedy = (" The background daemon is not running, so nothing will close this "
+                  "automatically — run `tj backfill claude-code`.")
+    else:
+        remedy = (" Automatic catch-up is off ([ingest] auto_catch_up) — run "
+                  "`tj backfill claude-code`.")
     return {
         "name": name,
-        "level": "warning",
+        "level": "warning" if self_heals else "error",
         "message": (
             f"{report.missing_count} on-disk session(s) are not ingested."
             f"{horizon}{remedy}"

--- a/tokenjam/cli/cmd_onboard.py
+++ b/tokenjam/cli/cmd_onboard.py
@@ -3644,6 +3644,57 @@ def _warn_no_durable_daemon_entrypoint(unit_kind: str) -> None:
     )
 
 
+def _parse_launchctl_arguments(output: str) -> list[str] | None:
+    """Extract the ``arguments = { ... }`` array `launchctl print` reports
+    for a loaded unit out of its text output.
+
+    Returns ``None`` when the block isn't present at all (unit not loaded,
+    or a launchctl version whose output this doesn't understand) so a
+    caller can tell "couldn't check" apart from "checked, and it's empty" —
+    the two must never be conflated into a false positive.
+    """
+    lines = output.splitlines()
+    in_block = False
+    found = False
+    args: list[str] = []
+    for line in lines:
+        stripped = line.strip()
+        if not in_block:
+            if stripped.startswith("arguments = {"):
+                in_block = True
+                found = True
+            continue
+        if stripped == "}":
+            break
+        if stripped:
+            args.append(stripped)
+    return args if found else None
+
+
+def _launchd_registration_matches(
+    target: str, program_args: list[str],
+) -> bool | None:
+    """Does the ACTIVELY loaded unit at `target` run `program_args` — the
+    plist that was just written?
+
+    `launchctl print` exiting 0 only proves SOME unit is registered under
+    this label; it says nothing about whether that's the registration this
+    run just wrote versus an old one `bootout` failed to clear (the label
+    is loaded either way, and "already bootstrapped" is exactly the signal
+    that the old one may still be active). Comparing the live argv against
+    what this run intended to install is what actually answers the
+    question. Returns `None` — not confirmed, not refuted — when the unit
+    isn't registered or its output can't be parsed at all.
+    """
+    verify = subprocess.run(["launchctl", "print", target], capture_output=True, text=True)
+    if verify.returncode != 0:
+        return None
+    active_args = _parse_launchctl_arguments(verify.stdout)
+    if active_args is None:
+        return None
+    return active_args == program_args
+
+
 def _launchd_target(label: str = "com.tokenjam.serve") -> tuple[str, str]:
     """``(domain, service-target)`` for this user's GUI launchd domain —
     ``gui/<uid>/<label>``, the specifier `bootstrap`/`bootout`/`enable`/`print`
@@ -3733,15 +3784,43 @@ def _install_launchd(config_path: str, *, suppress_headsup: bool = False) -> str
         return None
 
     # Verify registration independently rather than trusting bootstrap's exit
-    # status either — `launchctl print <target>` exits non-zero only when the
-    # service genuinely isn't registered, which is the actual question here.
-    verify = subprocess.run(["launchctl", "print", target], capture_output=True, text=True)
-    if verify.returncode != 0:
+    # status either — but "some unit is registered under this label" is the
+    # WRONG question when bootstrap reported "already bootstrapped": that
+    # means the old registration may still be the one actually loaded (bootout
+    # above raced or no-op'd against a job still shutting down), and a bare
+    # `launchctl print` happily confirms that stale unit — verifying the plist
+    # is on disk, not that it's what's running. Compare the ACTIVE unit's
+    # program arguments against what this run just wrote instead.
+    matches = _launchd_registration_matches(target, program_args)
+    if not matches:
+        # One retry of the full bootout -> enable -> bootstrap cycle before
+        # giving up — covers the "bootout raced" case outright.
+        subprocess.run(["launchctl", "bootout", target], capture_output=True, text=True)
+        subprocess.run(["launchctl", "enable", target], capture_output=True, text=True)
+        subprocess.run(
+            ["launchctl", "bootstrap", domain, str(plist_path)],
+            capture_output=True, text=True,
+        )
+        matches = _launchd_registration_matches(target, program_args)
+
+    if matches is None:
         console.print(f"[warn]Daemon plist written to {plist_path} but "
                       f"launchctl could not confirm it registered.[/warn]")
         console.print(f"[dim]Check manually:[/dim]  launchctl print {target}")
         console.print("[dim]Or run the server directly:[/dim]")
         console.print("  tj serve &")
+        return None
+    if matches is False:
+        console.print(
+            f"[warn]Daemon plist written to {plist_path}, but launchd is "
+            f"still running an OLD registration under {target} — its active "
+            f"program arguments don't match what was just written, so the "
+            f"new config/executable is NOT in effect.[/warn]"
+        )
+        console.print("[dim]Force a clean reload, then re-check:[/dim]")
+        console.print(f"  launchctl bootout {target}")
+        console.print(f"  launchctl bootstrap {domain} {plist_path}")
+        console.print(f"  launchctl print {target}")
         return None
 
     # The --claude-code completion (#675) moves this heads-up to the very BOTTOM

--- a/tokenjam/cli/cmd_onboard.py
+++ b/tokenjam/cli/cmd_onboard.py
@@ -3644,6 +3644,14 @@ def _warn_no_durable_daemon_entrypoint(unit_kind: str) -> None:
     )
 
 
+def _launchd_target(label: str = "com.tokenjam.serve") -> tuple[str, str]:
+    """``(domain, service-target)`` for this user's GUI launchd domain —
+    ``gui/<uid>/<label>``, the specifier `bootstrap`/`bootout`/`enable`/`print`
+    all take (see the ``launchctl`` man page's SUBCOMMANDS section)."""
+    domain = f"gui/{os.getuid()}"
+    return domain, f"{domain}/{label}"
+
+
 def _install_launchd(config_path: str, *, suppress_headsup: bool = False) -> str | None:
     program_args = _daemon_program_args(config_path)
     if program_args is None:
@@ -3675,27 +3683,67 @@ def _install_launchd(config_path: str, *, suppress_headsup: bool = False) -> str
 </dict>
 </plist>"""
     plist_path.write_text(plist_content)
-    # Unload any existing registration before loading the updated plist.
-    # Ignore errors — the service may not be registered yet on first install.
-    subprocess.run(
-        ["launchctl", "unload", "-w", str(plist_path)],
-        capture_output=True, text=True,
-    )
-    # `-w` clears the Disabled=true flag that `tj stop` writes via
-    # `launchctl unload -w`. Without `-w` here, the daemon stays disabled
-    # in launchd's database and load is a no-op even though it returns 0.
+
+    domain, target = _launchd_target()
+
+    # `bootstrap`/`bootout`/`enable` replace the legacy `load`/`unload` this
+    # used to call. The `launchctl` man page lists them as the "Recommended
+    # alternative subcommands" for load/unload, and spells out exactly why
+    # trusting load/unload's exit status is unsafe: "the load and unload
+    # subcommands will only return a non-zero exit code due to improper
+    # usage. Otherwise, zero is always returned." A registration that
+    # silently never took (the label just isn't re-loaded into launchd) is
+    # therefore INDISTINGUISHABLE from success by exit code alone under the
+    # legacy call — which is exactly the failure mode observed in production:
+    # the plist was present with RunAtLoad/KeepAlive both true and no
+    # Disabled key, yet `launchctl list` showed nothing loaded, with no
+    # crash and no stderr trace. Because of that, this install path no
+    # longer trusts ANY single call's exit code — see the independent
+    # `print` verification below.
+
+    # Remove any existing registration first, so re-onboarding is idempotent
+    # regardless of prior state. `bootout` on a label that isn't currently
+    # loaded exits non-zero ("Could not find service") — ignored, since
+    # "nothing to remove" is exactly the common first-install case.
+    subprocess.run(["launchctl", "bootout", target], capture_output=True, text=True)
+
+    # `enable` clears the persisted Disabled bit that `tj stop`'s `launchctl
+    # unload -w` sets (`cmd_stop.py`) — the modern equivalent of `load -w`'s
+    # disable-clearing half. Without it the daemon stays disabled in
+    # launchd's on-disk database and `bootstrap` below is a no-op even
+    # though it still reports success.
+    subprocess.run(["launchctl", "enable", target], capture_output=True, text=True)
+
     result = subprocess.run(
-        ["launchctl", "load", "-w", str(plist_path)],
+        ["launchctl", "bootstrap", domain, str(plist_path)],
         capture_output=True, text=True,
     )
-    if result.returncode != 0:
+    combined = f"{result.stdout}\n{result.stderr}".lower()
+    # "already bootstrapped" would mean the `bootout` above raced or no-op'd
+    # against a job still shutting down — treat it as success and fall
+    # through to the independent verification rather than failing an
+    # otherwise-fine idempotent re-install.
+    if result.returncode != 0 and "already bootstrapped" not in combined:
         console.print(f"[warn]Daemon plist written to {plist_path} but "
-                      f"launchctl load failed.[/warn]")
+                      f"launchctl bootstrap failed.[/warn]")
         console.print("[dim]Try loading manually:[/dim]")
-        console.print(f"  launchctl load {plist_path}")
+        console.print(f"  launchctl bootstrap {domain} {plist_path}")
         console.print("[dim]Or run the server directly:[/dim]")
         console.print("  tj serve &")
         return None
+
+    # Verify registration independently rather than trusting bootstrap's exit
+    # status either — `launchctl print <target>` exits non-zero only when the
+    # service genuinely isn't registered, which is the actual question here.
+    verify = subprocess.run(["launchctl", "print", target], capture_output=True, text=True)
+    if verify.returncode != 0:
+        console.print(f"[warn]Daemon plist written to {plist_path} but "
+                      f"launchctl could not confirm it registered.[/warn]")
+        console.print(f"[dim]Check manually:[/dim]  launchctl print {target}")
+        console.print("[dim]Or run the server directly:[/dim]")
+        console.print("  tj serve &")
+        return None
+
     # The --claude-code completion (#675) moves this heads-up to the very BOTTOM
     # of the payoff screen (after Next steps) so it reads top-to-bottom, hence
     # `suppress_headsup` there; every other onboard path prints it inline here as

--- a/tokenjam/cli/cmd_status.py
+++ b/tokenjam/cli/cmd_status.py
@@ -172,6 +172,9 @@ def cmd_status(
         teaser = _recoverable_teaser(ctx.obj.get("config"))
         if teaser:
             console.print(teaser)
+        freshness_note = _ingest_freshness_note(ctx.obj.get("config"), db)
+        if freshness_note:
+            console.print(freshness_note)
 
     ctx.exit(1 if has_active_alerts else 0)
 
@@ -256,6 +259,41 @@ def _recoverable_teaser(config) -> str | None:
     except Exception:
         # Never let a teaser computation break `tj status` itself.
         return None
+
+
+def _ingest_freshness_note(config: object, db: object) -> str | None:
+    """One-line nudge when nothing has been ingested for far longer than the
+    configured `[ingest] interval_minutes` cadence.
+
+    Shares its staleness math with `tj doctor`'s "Corpus freshness" check
+    (`core/ingest_freshness.py`) so the two surfaces can't silently disagree
+    about what "stale" means. Three-state gating (root anti-pattern 22):
+    silent when there's no config/DB to read (not-yet-known — never a
+    fabricated claim), silent when the corpus genuinely isn't stale
+    (known-and-fine — nothing worth a line), and a line ONLY once it's known
+    to actually be stale. This is purely advisory — unlike `tj doctor`, `tj
+    status` never fails on it, since a quiet corpus is also the everyday
+    state of a user who simply hasn't run an agent in a while.
+    """
+    if config is None:
+        return None
+    try:
+        if not hasattr(db, "conn"):
+            return None
+        from tokenjam.core.ingest_freshness import corpus_freshness
+
+        interval_minutes = getattr(getattr(config, "ingest", None), "interval_minutes", 30)
+        freshness = corpus_freshness(db.conn, interval_minutes, now=utcnow())
+    except Exception:
+        # Never let an advisory note break `tj status` itself.
+        return None
+    if freshness.newest_session_at is None or not freshness.is_stale:
+        return None
+    return (
+        f"[warn]⚠ Last session ingested {freshness.age_hours:.0f}h ago[/warn] "
+        f"(expected roughly every {interval_minutes}m) — run "
+        f"[bold]tj doctor[/bold] to check the background daemon."
+    )
 
 
 def _fmt_dur(seconds: float | None, *, coarse: bool = False) -> str:

--- a/tokenjam/core/api_backend.py
+++ b/tokenjam/core/api_backend.py
@@ -6,7 +6,7 @@ queries through the REST API.
 from __future__ import annotations
 
 from datetime import date, datetime, timedelta, timezone
-from typing import Any, cast
+from typing import Any
 
 import httpx
 
@@ -112,14 +112,14 @@ class ApiBackend:
             params["span_name"] = filters.span_name
         data = self._get("/api/v1/traces", params)
         return [
+            # `TraceRecord.start_time` is non-Optional (models.py) for the same
+            # reason `NormalizedSpan.start_time` is — see the guard in
+            # `_dict_to_span` below; the same lying `cast()` used to sit here.
             TraceRecord(
                 trace_id=t["trace_id"],
                 agent_id=t["agent_id"],
                 name=t["name"],
-                start_time=cast(
-                    datetime,
-                    datetime.fromisoformat(t["start_time"]) if t.get("start_time") else None,
-                ),
+                start_time=_require_start_time(t),
                 duration_ms=t.get("duration_ms"),
                 cost_usd=t.get("cost_usd"),
                 status_code=t.get("status_code", "ok"),
@@ -554,6 +554,25 @@ class ApiBackend:
         self.client.close()
 
 
+def _require_start_time(d: dict) -> datetime:
+    """Parse a wire record's ``start_time``, or fail loudly if it's missing.
+
+    ``NormalizedSpan.start_time`` and ``TraceRecord.start_time`` are both
+    non-Optional by design (models.py): ingest already rejects any span with
+    no observed time rather than substituting a default, so a record the
+    daemon serialized always carries a real ``start_time``. A missing or
+    unparseable value here means the wire response itself is malformed, not
+    that the field is legitimately absent — fail loudly instead of passing a
+    `None` off as a `datetime` (a `cast()` used to paper over exactly that,
+    silently disabling the type checker for every downstream consumer that
+    dereferences `start_time` unguarded).
+    """
+    if not d.get("start_time"):
+        ident = d.get("span_id") or d.get("trace_id")
+        raise ValueError(f"record {ident!r} has no start_time in API response")
+    return datetime.fromisoformat(d["start_time"])
+
+
 def _dict_to_span(d: dict) -> NormalizedSpan:
     return NormalizedSpan(
         span_id=d["span_id"],
@@ -561,10 +580,7 @@ def _dict_to_span(d: dict) -> NormalizedSpan:
         name=d["name"],
         kind=SpanKind(d.get("kind", "internal")),
         status_code=SpanStatus(d.get("status_code", "ok")),
-        start_time=cast(
-            datetime,
-            datetime.fromisoformat(d["start_time"]) if d.get("start_time") else None,
-        ),
+        start_time=_require_start_time(d),
         parent_span_id=d.get("parent_span_id"),
         session_id=d.get("session_id"),
         agent_id=d.get("agent_id"),

--- a/tokenjam/core/db.py
+++ b/tokenjam/core/db.py
@@ -3601,7 +3601,7 @@ class DuckDBBackend:
         # columns on `spans` (see migration 17).
         attribution_dims = ("tenant", "feature", "environment", "prompt_version")
         group_col_map = {
-            "day": "CAST(start_time AS DATE)",
+            "day": "CAST(start_time AT TIME ZONE 'UTC' AS DATE)",
             "agent": "agent_id",
             "model": "model",
             "tool": "tool_name",
@@ -3610,7 +3610,9 @@ class DuckDBBackend:
             "environment": "environment",
             "prompt_version": "prompt_template_version",
         }
-        group_expr = group_col_map.get(filters.group_by, "CAST(start_time AS DATE)")
+        group_expr = group_col_map.get(
+            filters.group_by, "CAST(start_time AT TIME ZONE 'UTC' AS DATE)"
+        )
 
         # gen_ai.tool.call spans are separate rows from the LLM completion
         # spans that carry model/cost/tokens (otel/otlp_parsing.py) — a span

--- a/tokenjam/core/ingest_freshness.py
+++ b/tokenjam/core/ingest_freshness.py
@@ -1,0 +1,58 @@
+"""Shared corpus-freshness math for `tj doctor` and `tj status`.
+
+Both surfaces answer "how long since anything was ingested" — doctor's
+pass/fail check and status's advisory nudge — against the same threshold,
+derived from the daemon's own configured ingest cadence
+(``[ingest] interval_minutes``) rather than each guessing its own constant,
+so they can never silently disagree about what "stale" means.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+# "Stale" means the newest ingested session is older than this many multiples
+# of the configured ingest interval — wide enough that a single missed cycle
+# (daemon briefly restarting, a slow backfill) never fires, tight enough to
+# catch a daemon that has been silently dead for a meaningful stretch. The
+# floor guards a very short configured interval from producing a sub-hour
+# threshold that would fire during a completely normal idle stretch.
+STALENESS_INTERVAL_MULTIPLIER = 6
+STALENESS_FLOOR_HOURS = 2.0
+
+
+def staleness_threshold_hours(interval_minutes: int) -> float:
+    """The corpus-staleness threshold, in hours, for a given ingest cadence."""
+    return max(
+        STALENESS_FLOOR_HOURS,
+        interval_minutes * STALENESS_INTERVAL_MULTIPLIER / 60.0,
+    )
+
+
+@dataclass(frozen=True)
+class CorpusFreshness:
+    newest_session_at: datetime | None
+    age_hours: float | None
+    threshold_hours: float
+    is_stale: bool
+
+
+def corpus_freshness(conn, interval_minutes: int, *, now: datetime) -> CorpusFreshness:
+    """Read the newest ``sessions.started_at`` and compare it to the
+    cadence-derived threshold.
+
+    ``now`` is injected (matches the rest of the codebase's ``utcnow()``
+    seam) so callers/tests never depend on wall-clock time. Never raises on
+    "no sessions yet" — that's a legitimate pre-ingest state, not staleness
+    (mirrors ``_check_span_staleness``'s empty-DB handling in
+    ``cmd_doctor.py``).
+    """
+    threshold = staleness_threshold_hours(interval_minutes)
+    row = conn.execute("SELECT MAX(started_at) FROM sessions").fetchone()
+    newest = row[0] if row else None
+    if newest is None:
+        return CorpusFreshness(None, None, threshold, False)
+    if newest.tzinfo is None:
+        newest = newest.replace(tzinfo=timezone.utc)
+    age_hours = (now - newest).total_seconds() / 3600.0
+    return CorpusFreshness(newest, age_hours, threshold, age_hours > threshold)

--- a/tokenjam/core/optimize/runner.py
+++ b/tokenjam/core/optimize/runner.py
@@ -274,7 +274,7 @@ def summarize_window(
     row = conn.execute(
         f"SELECT COUNT(*) AS spans, "
         f"COUNT(DISTINCT session_id) AS sessions, "
-        f"COUNT(DISTINCT CAST(start_time AS DATE)) AS active_days, "
+        f"COUNT(DISTINCT CAST(start_time AT TIME ZONE 'UTC' AS DATE)) AS active_days, "
         f"COALESCE(SUM(COALESCE(input_tokens,0) + COALESCE(output_tokens,0) + COALESCE(cache_tokens,0) + COALESCE(cache_write_tokens,0)), 0) AS tokens, "
         f"COALESCE(SUM(cost_usd), 0.0) AS cost "
         f"FROM spans WHERE {where}",


### PR DESCRIPTION
## How to merge this

**Use "Create a merge commit". Do not squash, do not rebase.**

This PR is the anchor for a batch of three. Two sibling PRs have been merged into this branch and will
flip to Merged automatically when this lands — but only because their commits are preserved here. A
squash or rebase rewrites those commit SHAs, and both siblings are stranded open with stale diffs that
can never be closed cleanly.

Rides along with this PR:
- https://github.com/Metabuilder-Labs/tokenjam/pull/713
- https://github.com/Metabuilder-Labs/tokenjam/pull/714

## What this batch is

Three independent silent-failure bugs. Each one is a surface that reported success, or reported
nothing, while the thing underneath was broken — a stale build served forever, a day boundary drawn in
the wrong timezone, an ingestion pipeline that had simply stopped.

### 1. The daemon's launchd registration, and its silent death (this PR)

Ingestion had stopped for ~2 days on a real machine with nothing anywhere reporting it. The LaunchAgent
plist was present with `RunAtLoad` and `KeepAlive` both true and no `Disabled` key, yet
`launchctl list` showed nothing — the unit was simply never re-registered, and there was no error log
to read because the job never started.

This is not an availability annoyance. Claude Code prunes its own transcripts on `cleanupPeriodDays`,
so every day the daemon is dead is a day of history that becomes permanently unrecoverable. It also
drags every analyzer figure downward with no signal, which reads to the user as "you have less waste
now".

- **Registration made durable.** `launchctl load -w` is deprecated; `man launchctl` states the legacy
  subcommands "will only return a non-zero exit code due to improper usage. Otherwise, zero is always
  returned" — an exit status that structurally cannot report a registration that never took. Install
  now uses `bootout` + `enable` + `bootstrap gui/<uid>`, and independently verifies with
  `launchctl print` rather than trusting any exit code.
- **Verification checks the right unit.** Review caught that an "already bootstrapped" result could be
  accepted while `launchctl print` merely confirmed the *old* registration was still loaded — onboard
  would report success with the newly written plist inactive. Verification now parses the loaded
  unit's `arguments` block and compares it against the plist just written, retries the
  bootout→bootstrap sequence once on a mismatch, and then fails loudly with recovery instructions.
- **Stoppage made loud.** `tj doctor` now reports daemon liveness and corpus freshness and exits
  non-zero past a threshold derived from `[ingest] interval_minutes`
  (`max(STALENESS_FLOOR_HOURS, interval_minutes * STALENESS_INTERVAL_MULTIPLIER)`), shared with
  `tj status` so the two surfaces cannot disagree. `tj status` carries a matching advisory line.
- **Idle is not the same as broken.** Review caught that a user who simply had not run an agent for a
  while would trip the freshness check, exit 2, and be told to backfill. Freshness now reconciles
  against on-disk transcripts: no newer transcript than the newest ingested session means ingestion is
  healthy however old the corpus is. Unverifiable reconciliation reports as `info`, never as healthy
  and never as failing.

An existing test, `TestLaunchdInstallUsesWFlag`, was pinning the deprecated `load -w` behaviour. It was
inverted rather than deleted, so the same test now defends the new sequence. A second existing test was
passing on empty `launchctl print` stdout — precisely the false positive described above — and now
supplies realistic output.

**Not verified: reboot survival.** No amount of unit testing establishes that the new registration
persists across a real reboot. After merging, reboot and confirm with
`launchctl print gui/$(id -u)/com.tokenjam.serve`.

### 2. `npx tokenjam` served a permanently stale build (713)

`publish-npm.yml` and `publish-pypi.yml` both fire on the same `release: published` event with no
ordering between them. The PyPI job runs the full test suite before building; the npm job only syntax-
checks, so the wrapper reliably goes live first. The wrapper pinned `uvx --from tokenjam==<version>`
but fell back to the *unpinned* spec when the pin had not yet propagated — and uv caches a resolved
tool environment against the spec string forever. A publish-ordering window of minutes therefore
converted into a permanently stale environment on the user's machine.

Observed for real after 0.6.2: the PyPI wheel was downloaded and verified to contain the new palette,
while a fresh `npx tokenjam` still rendered the old one.

- The npm job now polls the per-version PyPI JSON endpoint before publishing, treating HTTP 200 as the
  only success signal, and fails the job on timeout rather than publishing ahead of the artifact it
  pins to. Verified against live PyPI: an existing version resolves immediately, `999.0.0` polls and
  then correctly fails.
- The wrapper fails closed. An unresolvable pin skips that runner rather than silently falling back to
  an unpinned spec, and exits non-zero with retry guidance if nothing resolves. Review caught that the
  PATH fallback would resolve to this package's own shim under `npx` and recurse into itself; the
  candidate is now realpath-compared against the wrapper and rejected before it is ever spawned.

**Not verified end-to-end.** The gate only fires during a real release, and cutting one to test it is
irreversible — PyPI version numbers cannot be reused. The first release after this merges is the live
test.

### 3. Day boundaries drawn in the wrong timezone (714)

`spans.start_time` is `TIMESTAMPTZ`, and a bare `CAST(... AS DATE)` converts to the session's local
timezone first. Three live sites still used the bare form, so `tj cost --group-by day` bucketed by
local date and silently disagreed with the UI's UTC-day totals. The third,
`COUNT(DISTINCT CAST(start_time AS DATE)) AS active_days`, feeds every per-day extrapolation in the
optimize report, so the error propagated into derived figures rather than staying cosmetic. All three
are green in a UTC-configured CI, which is why they survived.

Also in this component: `_dict_to_span` used `cast(datetime, ... if ... else None)` — a cast that
converts nothing and merely tells the type checker to stop looking while a `None` flows through the
HTTP-fallback read path. `start_time` is required (ingest already rejects untimed spans), so this now
raises a `ValueError` naming the offending record instead. The same defect was found and fixed in
`get_traces`.

Tests are parametrized across UTC, Asia/Kolkata and America/Los_Angeles, and were confirmed to fail
against the unfixed queries before being finalized.

## Verification

Full suite on the final tip: **5549 passed, 15 skipped, 2 xfailed, 0 failed** (278s).
`make lint` clean.

`make typecheck` reports one error, `tokenjam/core/config.py:640` (`bytes` + `str`). This is
**pre-existing and unrelated** — confirmed by stashing the batch's changes and re-running against the
merge tip alone, which produces the same single error. It was left alone rather than folded into an
unrelated bundle.

## Adjudications made on your behalf

- **The statusline was deliberately not given a staleness check.** Its header documents a hard
  constraint: no network, no `tj serve`, no DB open, a single linear pass over the transcript JSONL,
  always exit 0. A DB-backed freshness read would violate that, so the advisory went into `tj status`
  instead. The requirement was "at least one always-visible surface", which `tj status` satisfies.
- **`tj stop` was left on the legacy `launchctl unload -w` path.** Only the install path was reported
  broken, so widening the change was declined here; teardown now disagrees with install on the domain
  model and inherits the same lying-exit-code defect. Tracked separately as follow-up work.
- **No JS test harness was added for the wrapper.** None exists in this repo, and introducing test
  infrastructure was out of scope for a review fix. The wrapper change is covered by a syntax check
  only, as the rest of that file already is.
