### PR TITLE
Add a plugin marketplace manifest and put the plugin version in release lockstep

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "name": "tokenjam",
+  "owner": {
+    "name": "Metabuilder Labs",
+    "url": "https://tokenjam.dev"
+  },
+  "description": "Claude Code plugin marketplace for tokenjam: local-first token-cost observability and fixes.",
+  "plugins": [
+    {
+      "name": "tokenjam",
+      "source": "./plugin",
+      "description": "Local-first observability and cost control for Claude Code agents: a zero-token statusline showing context re-read %, savings/optimize reports, and a health check."
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,17 @@ jobs:
             exit 1
           fi
 
+      - name: Check pyproject.toml and plugin manifest versions match
+        run: |
+          PY_VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' pyproject.toml | head -1)
+          PLUGIN_VERSION=$(jq -r '.version' plugin/.claude-plugin/plugin.json)
+          echo "pyproject.toml:               $PY_VERSION"
+          echo "plugin/.claude-plugin/plugin.json:  $PLUGIN_VERSION"
+          if [ "$PY_VERSION" != "$PLUGIN_VERSION" ]; then
+            echo "::error::Version mismatch — pyproject.toml ($PY_VERSION) and plugin/.claude-plugin/plugin.json ($PLUGIN_VERSION) must match before cutting a release, or the plugin marketplace entry will lag. Run: ./scripts/release.sh <version>"
+            exit 1
+          fi
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ tj rules list        # the fixes that came out of it, and the files they'd land 
 TokenJam also ships as a Claude Code plugin — see [`plugin/`](plugin/) for the plugin source (`plugin/.claude-plugin/plugin.json`) and install instructions. It adds slash commands that wrap the `tj` CLI; it does not install anything on its own, so `tj` still needs to be on your `PATH` (`npx tokenjam@latest` or `pipx install tokenjam`).
 
 ```
+/plugin marketplace add Metabuilder-Labs/tokenjam
 /plugin install tokenjam
 /onboard    # wires the statusline, resume-brief hook, and local telemetry ingest — same as `tj onboard --claude-code`
 /status     # tj status

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -4,10 +4,12 @@
 # Usage: scripts/release.sh X.Y.Z
 #
 # Updates:
-#   - pyproject.toml            (PyPI package version)
-#   - sdk-ts/package.json       (npm @tokenjam/sdk version — hand-published, not CI-synced)
-#   - npm-wrapper/package.json  (local `npm pack` floor; CI overwrites this from the release
-#                                tag on publish, but keeping it current avoids local drift)
+#   - pyproject.toml                    (PyPI package version)
+#   - sdk-ts/package.json               (npm @tokenjam/sdk version — hand-published, not CI-synced)
+#   - npm-wrapper/package.json          (local `npm pack` floor; CI overwrites this from the release
+#                                        tag on publish, but keeping it current avoids local drift)
+#   - plugin/.claude-plugin/plugin.json (Claude Code plugin manifest version — CI's
+#                                        version-lockstep job checks this against pyproject.toml)
 #
 # After bumping, greps the repo for any other literal occurrence of the OLD version
 # string outside the files above, so a straggler (Dockerfile ARG, docs snippet, etc.)
@@ -72,7 +74,9 @@ echo "  updated pyproject.toml"
 # npm-wrapper is CI-synced from the release tag on publish, so its checked-in value
 # is only a floor for local `npm pack` and may already be behind — bump it too for
 # hygiene, but don't require it to have matched pyproject.toml beforehand.
-for pkg in sdk-ts/package.json npm-wrapper/package.json; do
+# plugin.json must also stay in lockstep with pyproject.toml — CI's version-lockstep
+# job checks it, and Claude Code only offers plugin updates when this field changes.
+for pkg in sdk-ts/package.json npm-wrapper/package.json plugin/.claude-plugin/plugin.json; do
   # Targeted regex replace (not JSON.parse + stringify) so the diff stays a
   # one-line version bump instead of reformatting the whole file.
   node -e "
@@ -105,6 +109,6 @@ fi
 
 echo
 echo "Done. Review the diff, commit, then cut the release:"
-echo "  git add pyproject.toml sdk-ts/package.json npm-wrapper/package.json"
+echo "  git add pyproject.toml sdk-ts/package.json npm-wrapper/package.json plugin/.claude-plugin/plugin.json"
 echo "  git commit -m 'chore: bump version to $NEW_VERSION'"
 echo "  gh release create v$NEW_VERSION --generate-notes"


### PR DESCRIPTION
## What

1. **Make the repo its own plugin marketplace.** Adds `.claude-plugin/marketplace.json` at the repo root, per the [plugin marketplace docs](https://code.claude.com/docs/en/plugin-marketplaces), with a relative-path plugin entry pointing at `plugin/`. This makes `/plugin marketplace add Metabuilder-Labs/tokenjam` resolve and offer the `tokenjam` plugin.

2. **Put the plugin manifest in the release lockstep.** `scripts/release.sh` now bumps `plugin/.claude-plugin/plugin.json` alongside `pyproject.toml`, `sdk-ts/package.json`, and `npm-wrapper/package.json`. CI's `version-lockstep` job gets a second check comparing the plugin manifest's version against `pyproject.toml`, so a drifted plugin version fails the build instead of shipping silently stale.

3. **README.** Adds the `/plugin marketplace add Metabuilder-Labs/tokenjam` line ahead of the existing `/plugin install tokenjam` line.

## Why the root `.claude-plugin/` doesn't collide with `CLAUDE.md` this time

An earlier commit moved `plugin.json` out of the repo root into `plugin/.claude-plugin/plugin.json` because `claude plugin validate --strict` treated the repo root as the *plugin's* root and flagged the repo's own `CLAUDE.md` as unrecognized plugin content. A marketplace manifest is a different validation path (`claude plugin validate <path>` auto-detects manifest vs. marketplace) that doesn't scan the rest of the directory as plugin content, so adding `.claude-plugin/marketplace.json` at the root does not reproduce that collision — confirmed below.

## Verification

**Marketplace + plugin manifests both validate clean:**
```
$ claude plugin validate . --strict
Validating marketplace manifest: .../tokenjam/.claude-plugin/marketplace.json
✔ Validation passed

$ claude plugin validate ./plugin --strict
Validating plugin manifest: .../tokenjam/plugin/.claude-plugin/plugin.json
✔ Validation passed
```

**Local marketplace round trip (add -> list -> install -> details -> uninstall -> remove), confirming CLAUDE.md is not flagged and the plugin resolves with its 5 commands and 0 hooks/MCP servers:**
```
$ claude plugin marketplace add "$(pwd)"
Adding marketplace…✔ Successfully added marketplace: tokenjam (declared in user settings)

$ claude plugin marketplace list
  ...
  ❯ tokenjam
    Source: Directory (/.../plugin-marketplace/tokenjam)

$ claude plugin install tokenjam@tokenjam -y
Installing plugin "tokenjam@tokenjam"...✔ Successfully installed plugin: tokenjam@tokenjam (scope: user)

$ claude plugin details tokenjam@tokenjam
TokenJam (tokenjam) 0.6.9
  Component inventory
  Skills (5)  doctor, onboard, optimize, status, uninstall
  Agents (0)  Hooks (0)  MCP servers (0)  LSP servers (0)

$ claude plugin uninstall tokenjam@tokenjam -s user
✔ Successfully uninstalled plugin: tokenjam (scope: user)

$ claude plugin marketplace remove tokenjam
✔ Successfully removed marketplace: tokenjam
```
Confirmed no leftover state: `claude plugin marketplace list` and `claude plugin list` no longer show `tokenjam` afterward.

**`scripts/release.sh` now touches all four files** (dry run for a throwaway version, then reverted, no version bump committed here):
```
$ bash scripts/release.sh 0.6.10
Bumping to 0.6.10 (pyproject.toml was 0.6.9)
  updated pyproject.toml
  updated sdk-ts/package.json
  updated npm-wrapper/package.json
  updated plugin/.claude-plugin/plugin.json

Checking for stragglers still referencing 0.6.9...
no stragglers found.
```
Then `git checkout -- pyproject.toml sdk-ts/package.json npm-wrapper/package.json plugin/.claude-plugin/plugin.json` to revert the version churn (a real release is a separate, human-run step).

**New CI lockstep assertion actually fails on a mismatch** (ran the exact step body against a deliberately skewed plugin manifest, then restored it):
```
# baseline (0.6.9 == 0.6.9): exit 0
# skewed plugin.json to 9.9.9: OBSERVED EXIT CODE: 1, with the ::error:: message
```

**Not run:** the repo's pytest suite has no tests covering `scripts/release.sh`, the marketplace manifest, or the CI workflow YAML (grep for `release.sh`/`marketplace`/plugin manifest across `tests/` came back empty), so there was nothing applicable to run there — the shell/CLI verification above is the coverage for this change.
