### PR TITLE
chore: bump version to 0.6.10

### DIFF
--- a/npm-wrapper/package.json
+++ b/npm-wrapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenjam",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "description": "Zero-install launcher for TokenJam (tj): npx tokenjam runs the Python CLI via uvx/pipx and reports the recurring mistakes your AI agent keeps repeating, no setup required.",
   "keywords": ["claude-code", "ccusage", "tokens", "cost-optimization", "llm", "agents", "observability", "tokenjam", "anthropic", "claude", "token-usage", "agent-behavior", "cli", "statusline", "opentelemetry", "agent-observability"],
   "homepage": "https://tokenjam.dev",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "tokenjam",
   "displayName": "TokenJam",
   "description": "Local-first observability and cost control for Claude Code agents: a zero-token statusline showing context re-read %, savings/optimize reports, and a health check. Runs 100% locally against your own telemetry, no signup or network account required.",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "author": {
     "name": "Anil Murty",
     "email": "anil@metabldr.com",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tokenjam"
-version = "0.6.9"
+version = "0.6.10"
 description = "TokenJam: a local-first, OTel-native cost-saving utility for AI agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenjam/sdk",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "description": "TypeScript SDK for TokenJam — local-first observability for AI agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Version bump to 0.6.10 across all four lockstep files: `pyproject.toml`, `sdk-ts/package.json`, `npm-wrapper/package.json`, and `plugin/.claude-plugin/plugin.json`.

Generated by `scripts/release.sh 0.6.10`; no stragglers on the old version string. This is the first bump since the plugin manifest joined the lockstep, so the plugin version now tracks the shipped CLI.

Releasing this picks up the daemon registration and staleness fixes, the UTC day-bucketing correction, the relearn store refresh, and the plugin packaging. Those matter for the plugin's `/status` and `/doctor` commands, which shell out to the installed `tj`.