### PR TITLE
Fix plugin slash-command docs to use the namespaced form

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,15 +65,15 @@ TokenJam also ships as a Claude Code plugin — see [`plugin/`](plugin/) for the
 
 ```
 /plugin marketplace add Metabuilder-Labs/tokenjam
-/plugin install tokenjam
-/onboard    # wires the statusline, resume-brief hook, and local telemetry ingest — same as `tj onboard --claude-code`
-/status     # tj status
-/optimize   # tj optimize
-/doctor     # tj doctor
-/uninstall  # tj uninstall --yes
+/plugin install tokenjam@tokenjam
+/tokenjam:onboard    # wires the statusline, resume-brief hook, and local telemetry ingest — same as `tj onboard --claude-code`
+/tokenjam:status     # tj status
+/tokenjam:optimize   # tj optimize
+/tokenjam:doctor     # tj doctor
+/tokenjam:uninstall  # tj uninstall --yes
 ```
 
-The plugin deliberately does not ship its own hooks or an `.mcp.json`: the statusline and hooks are wired by `/onboard` calling the existing, idempotent `tj onboard --claude-code`, so there's exactly one writer of `~/.claude/settings.json`. TokenJam's MCP server (`tj mcp`) also stays opt-in and out of this plugin's default install — it's built for SDK/API integrations that already sit in the request path, not for Claude Code, where an in-loop MCP measurably taxes every turn.
+The plugin deliberately does not ship its own hooks or an `.mcp.json`: the statusline and hooks are wired by `/tokenjam:onboard` calling the existing, idempotent `tj onboard --claude-code`, so there's exactly one writer of `~/.claude/settings.json`. TokenJam's MCP server (`tj mcp`) also stays opt-in and out of this plugin's default install — it's built for SDK/API integrations that already sit in the request path, not for Claude Code, where an in-loop MCP measurably taxes every turn.
 
 ---
 

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -17,22 +17,24 @@ The plugin lives in a subdirectory of the `tokenjam` repo, so install it via a `
 }
 ```
 
-Or, once listed in a marketplace: `/plugin install tokenjam`.
+Or, once listed in a marketplace: `/plugin install tokenjam@tokenjam`.
 
 ## Commands
 
-| Command      | Runs                       | Does |
-|--------------|-----------------------------|------|
-| `/onboard`   | `tj onboard --claude-code`  | Wires the zero-token statusline, the resume-brief `SessionStart` hook, and local OTel telemetry ingest. Idempotent — safe to re-run. |
-| `/status`    | `tj status`                 | Token usage, cost today, active alerts, per agent. |
-| `/optimize`  | `tj optimize`                | Savings report: where quota is going and the concrete fix for each finding. |
-| `/doctor`    | `tj doctor`                  | Health check on config, ingest endpoint, and storage. |
-| `/uninstall` | `tj uninstall --yes`         | Unwires the statusline, hooks, and OTel env vars `/onboard` set up. |
+Claude Code namespaces every plugin command to `/<plugin-name>:<command>`; this plugin's name (from `plugin.json`) is `tokenjam`.
+
+| Command                | Runs                        | Does |
+|-------------------------|-----------------------------|------|
+| `/tokenjam:onboard`   | `tj onboard --claude-code`  | Wires the zero-token statusline, the resume-brief `SessionStart` hook, and local OTel telemetry ingest. Idempotent — safe to re-run. |
+| `/tokenjam:status`    | `tj status`                 | Token usage, cost today, active alerts, per agent. |
+| `/tokenjam:optimize`  | `tj optimize`                | Savings report: where quota is going and the concrete fix for each finding. |
+| `/tokenjam:doctor`    | `tj doctor`                  | Health check on config, ingest endpoint, and storage. |
+| `/tokenjam:uninstall` | `tj uninstall --yes`         | Unwires the statusline, hooks, and OTel env vars `/tokenjam:onboard` set up. |
 
 ## Why no `hooks.json` or `.mcp.json`
 
 This plugin ships neither, on purpose:
 
-- **Statusline.** A plugin's own `settings.json` only supports the `agent` and `subagentStatusLine` keys — there is no plugin-manifest path to the main terminal `statusLine` ([plugins-reference](https://code.claude.com/docs/en/plugins-reference), "File locations reference" table; [statusline docs](https://code.claude.com/docs/en/statusline#subagent-status-lines)). `/onboard` gets there by calling `tj onboard --claude-code` instead, which writes `statusLine` directly into the user's `~/.claude/settings.json`.
-- **Hooks.** `tj onboard --claude-code` already writes a `SessionStart` hook (`tj resume-brief --from-hook`) into the user's global settings, matched/deduped by a marker in the command string. A second, independent `hooks/hooks.json` in this plugin would not recognize that marker and would double-fire the hook on every session start. Routing through `/onboard` keeps `~/.claude/settings.json` to one writer.
+- **Statusline.** A plugin's own `settings.json` only supports the `agent` and `subagentStatusLine` keys — there is no plugin-manifest path to the main terminal `statusLine` ([plugins-reference](https://code.claude.com/docs/en/plugins-reference), "File locations reference" table; [statusline docs](https://code.claude.com/docs/en/statusline#subagent-status-lines)). `/tokenjam:onboard` gets there by calling `tj onboard --claude-code` instead, which writes `statusLine` directly into the user's `~/.claude/settings.json`.
+- **Hooks.** `tj onboard --claude-code` already writes a `SessionStart` hook (`tj resume-brief --from-hook`) into the user's global settings, matched/deduped by a marker in the command string. A second, independent `hooks/hooks.json` in this plugin would not recognize that marker and would double-fire the hook on every session start. Routing through `/tokenjam:onboard` keeps `~/.claude/settings.json` to one writer.
 - **MCP.** `tj mcp` is tokenjam's in-request-path surface, built for SDK/API integrations that already sit in the loop. A measured A/B showed an in-loop MCP costs Claude Code / subscription users +36% model-weighted tokens versus the zero-token statusline — auto-wiring it here would regress the exact thing `tj onboard --claude-code` deliberately avoids. Run `tj mcp` yourself (or `claude mcp add tj -- tj mcp`) if you want it for an SDK-style use case.

--- a/tests/unit/test_plugin_command_docs_namespaced.py
+++ b/tests/unit/test_plugin_command_docs_namespaced.py
@@ -1,0 +1,84 @@
+"""Docs must advertise the plugin's slash commands namespaced, not bare.
+
+Claude Code namespaces every plugin-provided command as `/<plugin-name>:<command>`,
+where the prefix is the `name` field in `plugin.json` (not the repo name, and not
+hand-picked by the docs author). The bare form (`/onboard`) matches nothing once
+the plugin is installed: it was documented that way in both READMEs and only
+caught by manual reproduction, not by any test.
+
+This guard reads the real command set straight from `plugin/commands/*.md` and
+the real prefix straight from `plugin/.claude-plugin/plugin.json`, so a renamed
+plugin or an added/removed command is caught automatically rather than by
+remembering to update a hand-kept list here.
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PLUGIN_DIR = _REPO_ROOT / "plugin"
+_COMMANDS_DIR = _PLUGIN_DIR / "commands"
+_PLUGIN_MANIFEST = _PLUGIN_DIR / ".claude-plugin" / "plugin.json"
+_DOC_FILES = [_REPO_ROOT / "README.md", _PLUGIN_DIR / "README.md"]
+
+
+def _plugin_prefix() -> str:
+    manifest = json.loads(_PLUGIN_MANIFEST.read_text())
+    return manifest["name"]
+
+
+def _command_stems() -> list[str]:
+    return sorted(p.stem for p in _COMMANDS_DIR.glob("*.md"))
+
+
+def _bare_command_references(text: str, stem: str) -> list[str]:
+    """Occurrences of `/<stem>` NOT preceded by `:` (i.e. not `...:<stem>`)."""
+    pattern = re.compile(r"(?<![:\w])/" + re.escape(stem) + r"\b")
+    return pattern.findall(text)
+
+
+# --------------------------------------------------------------------------- #
+# The guard has to be able to fail before it can be trusted to pass
+# --------------------------------------------------------------------------- #
+
+def test_the_guard_finds_at_least_one_command():
+    """If extraction ever finds zero commands, the checks below pass
+    vacuously — that must itself be a failure, not silent success."""
+    stems = _command_stems()
+    assert stems, f"no command files found under {_COMMANDS_DIR}"
+
+
+def test_the_guard_flags_a_bare_command_reference():
+    assert _bare_command_references("See /onboard for details.", "onboard") == [
+        "/onboard"
+    ]
+    # namespaced form must not trip the bare-form detector
+    assert _bare_command_references("See /tokenjam:onboard for details.", "onboard") == []
+
+
+# --------------------------------------------------------------------------- #
+# The actual docs
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.parametrize(
+    "doc_path", _DOC_FILES, ids=[str(p.relative_to(_REPO_ROOT)) for p in _DOC_FILES]
+)
+def test_docs_use_the_namespaced_command_form(doc_path):
+    prefix = _plugin_prefix()
+    stems = _command_stems()
+    assert stems, f"no command files found under {_COMMANDS_DIR}"
+    text = doc_path.read_text()
+
+    for stem in stems:
+        namespaced = f"/{prefix}:{stem}"
+        bare_hits = _bare_command_references(text, stem)
+        assert not bare_hits, (
+            f"{doc_path.relative_to(_REPO_ROOT)} documents the bare command "
+            f"`/{stem}`, which Claude Code will not resolve — it must be "
+            f"`{namespaced}` (prefix comes from plugin.json's `name`: "
+            f"{prefix!r})."
+        )


### PR DESCRIPTION
## Summary
- Claude Code namespaces every plugin command as `/<plugin-name>:<command>` (prefix from `plugin.json`'s `name`, which is `tokenjam`). Both READMEs documented the bare forms (`/onboard`, `/status`, `/optimize`, `/doctor`, `/uninstall`), which do not resolve once the plugin is installed. Reproduced live: typing `/onboard` after a successful marketplace add + install matches nothing.
- Corrected all references (table entries and mid-sentence prose) in `README.md` and `plugin/README.md` to the namespaced form, and fixed the install line to `/plugin install tokenjam@tokenjam`.
- Added `tests/unit/test_plugin_command_docs_namespaced.py`, which derives the command set from `plugin/commands/*.md` and the prefix from `plugin.json` at test time (not hardcoded), so a rename or a newly added/removed command is caught automatically if the docs drift again.

## Test plan
- [x] `python3 -m pytest tests/unit/test_plugin_command_docs_namespaced.py -v` — 4 passed
- [x] Confirmed the guard actually fails: temporarily reintroduced a bare `/onboard` in `README.md`, reran the test, observed a real `AssertionError` failure with a useful message, then restored and reran to confirm it passes again
- [x] `claude plugin validate ./plugin --strict` — Validation passed
- [x] Grepped the existing test suite for the bare command strings before editing; all hits were unrelated `/api/v1/*` HTTP routes and code comments, not plugin slash-command docs, so nothing needed inverting